### PR TITLE
fix 3.14.0a5

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -14,18 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.x"
-
-      - name: set up environment
-        run: |
-          python -m venv env
-          ./env/bin/python -m pip install -r requirements.txt
+          version: "latest"
 
       - name: check for new versions
         run: |
-          ./env/bin/python fetcher.py
+          ./fetcher.py
 
       - name: create PR
         uses: peter-evans/create-pull-request@v6

--- a/fetcher.py
+++ b/fetcher.py
@@ -1,4 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "urllib3",
+#     "lxml",
+#     "packaging",
+# ]
+# ///
 
 # fetcher: fetch hashes for each Python version
 
@@ -101,7 +109,9 @@ def do_sigstore(version: Version) -> None:
 
 
 def do_sigstore_identities() -> None:
-    sigstore_info = urllib3.request("GET", "https://www.python.org/downloads/metadata/sigstore/")
+    sigstore_info = urllib3.request(
+        "GET", "https://www.python.org/downloads/metadata/sigstore/"
+    )
     sigstore_info_doc = html.fromstring(sigstore_info.data)
 
     sigstore_table = sigstore_info_doc.xpath("//table")[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-urllib3
-packaging
-lxml
-lxml-stubs

--- a/versions/3.14.0a5.json
+++ b/versions/3.14.0a5.json
@@ -15,11 +15,11 @@
             "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
             "verificationMaterial": {
                 "certificate": {
-                    "rawBytes": "MIICzjCCAlSgAwIBAgIUJwCMF60N2vU3yo1vvZtYt2gAXZswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwMjExMTkzMDE2WhcNMjUwMjExMTk0MDE2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmBY7BK+mNiMR/jLHc1JmeSan4t0mhy5BkSI18ioMB3ZZvaMWEaRmDt9UDie1PdIjpjHE0fXU63tYuOXIiJR9uKOCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU+rqw8z41N2qKsFZ3k0r6RyZKTTgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlPZ9pCkAAAQDAEcwRQIhALc1sKQj8WmOCLfth+7VyvJ0mK8/oBL2JLWd+3ZMWiBGAiBVE3SWvaa01wIkKdJq2oO2nlZODv8We9rl+z1jidaFfTAKBggqhkjOPQQDAwNoADBlAjAy3g5QNRYB8iCtbUfZpJF4ovOsOC9kc2a+wQB0HEgcz0LW0ItiQ5O9bHWtsT/1dsECMQCGm3KQQ0oCXMZudew5kaMqbVkWleEXQkFPtgci0gKkmXZEb16qXY55LMvBeyHcf4o="
+                    "rawBytes": "MIICzzCCAlWgAwIBAgIUSNJPEIrcathw312kGEGcTwX/fDswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwMjEyMDc1NDI3WhcNMjUwMjEyMDgwNDI3WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7c46Hm1Llv3uGzoIFJ7o6qmtAkwqNELl1ut/xXtUHlyfKXAo6lY49XegG6V2PGp9S5jr1cfSiuFau/V9k5g3jqOCAXQwggFwMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUGWCKwgTZVL70viRqn1ZorGpx36cwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlPkm854AAAQDAEgwRgIhANuiGo8CCEuU8fh7z+LhBOcw2HwbteSWsB0NG7WqtAb1AiEAoCRhVn5sjlHdXFZHd6mycpyb5b31bC3YiuSnoPW1fAcwCgYIKoZIzj0EAwMDaAAwZQIxAP9yZxSnZ14ikzvW8AJcyQ8ZvkirXdjC+22MqB2qP1IglJACkLFeEhyjc5+EbEoM1gIwJl9AHadO7ohcvnxZrPZHpK/sPd/X+ehotFjwkqFpUSkNR8WCQJib+ptzyPDCuid6"
                 },
                 "tlogEntries": [
                     {
-                        "logIndex": "170370801",
+                        "logIndex": "170570081",
                         "logId": {
                             "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
                         },
@@ -27,44 +27,45 @@
                             "kind": "hashedrekord",
                             "version": "0.0.1"
                         },
-                        "integratedTime": "1739302217",
+                        "integratedTime": "1739346867",
                         "inclusionPromise": {
-                            "signedEntryTimestamp": "MEYCIQD7zjVy8V98LXWJpF1xdTOFpOpYSrXxqn6+KCYegOEUYwIhAJxXV7xbV0UNGoIxRE3ArL7kZ7s6DfGuTPy8S4i6i3qQ"
+                            "signedEntryTimestamp": "MEUCIBNalQl1QMr6Hs/9tOc280xY1HC0YWveZubFTBrwRMpHAiEAugk/MvQKqs7HBAMhsOsF7dMF+purrlsBkmWAeXKH8MU="
                         },
                         "inclusionProof": {
-                            "logIndex": "48466539",
-                            "rootHash": "J3ECMeBAGb41JjiMgOD5u3aRal5g2fkEuDoZj8xwz7U=",
-                            "treeSize": "48466540",
+                            "logIndex": "48665819",
+                            "rootHash": "Cm0abK/q+qL3cRk7T+ReKBF+hk28hsUgHg25AkLuPk0=",
+                            "treeSize": "48665820",
                             "hashes": [
-                                "Bes2Vg1Pg8QD9gZ92yPjq9JLgiohrIdfEEZCBB5cWEw=",
-                                "5Q6zGqA7BBqwHQ1EhPwdErxhdYC8FK2inHCdvoIKroY=",
-                                "X/izlkEj3nXAOW1PefOzNtAh1Y7ugBZydNjYluuUOuw=",
-                                "PvjraqFsd2TpEE/tukSzWKUECvoHobw8gwHWdUAPVKg=",
-                                "rn7NLbFfvPNbOXgXEWkrLv60O0RwOxUde75rLAlhwLY=",
-                                "uJeS9vHrt8GsXkJ3K2qDiitgQRmxdxZQDEpg8ZU88/w=",
-                                "AqQkj8KhPFRow/yeWhJ6qfkgA5M98xQ2O4IAHsQROvI=",
-                                "Tq7UWnwDGysF2R873ZsZ8MBhytL8JyQDuyeDr3/gCZc=",
-                                "yQk3XGa+J/GjPzdB1VYsHiVqAYpxymG1eW36uATfM2k=",
-                                "dKc+Z0lFxSZtZFebHmUcz/bS+EbsE1qMLGw8B/jxcRE=",
+                                "UQjT167VPCW2VkwjOwJSuIrWyrK3OS4aqgrKM+WFxec=",
+                                "2HRV4IIkaZvgg12HmKIPUhi7Qm6TlzkPnezCpoDfW5c=",
+                                "PzF8ffc9F8sd6tYvR38GwjGnIB98cBx3Thfg0Jy5hVc=",
+                                "H3EdRYMGRXSYlpgOc1+GDCOLlgGCjl0Z44SWqZ8esAo=",
+                                "OhZUVD4zjycOKN7gAu9nbQGQ9SLXbwyf90HuG8iWU50=",
+                                "6Z0kSTNv87FgCP6fBI6QTIRs0ABTmLD9tgAbSWRDRr0=",
+                                "p39Aj7k63Y8N82q5GXzhIzuZSex0HZN+9xq7U1Sxdp4=",
+                                "jhYil8zet/V88Ox8NV66V1iBkETlEJ2qH+SXo+kfMb0=",
+                                "Z/HAKVPPWMW9bRNxiWSaI+beB8FjcG/QYDqBuAZMTsY=",
+                                "cgbhJqDRiWT+2XKIQ9ch9WJ+6uwysr3Vn01jUW3nyv0=",
+                                "0NILEMXlPNU3cLx3pWSpe/u8BfMuXFyP+6HIsWDtkAU=",
                                 "3G1CfELRgkrpGc7BJBsecW/HvOojsTHpl40WsoH/3A0=",
                                 "Zse3BPkR/cJv62LvVuiDH+EpgIE5v3V3qXdG8HQFf1A=",
                                 "jU9+tgjTIKUYGeU7T7RjqyL+F+gFV9tCdwX2GZ1UtQs=",
                                 "vemyaMj0Na1LMjbB/9Dmkq8T+jAb3o+yCESgAayUABU="
                             ],
                             "checkpoint": {
-                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n48466540\nJ3ECMeBAGb41JjiMgOD5u3aRal5g2fkEuDoZj8xwz7U=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAl9jDeVp8nIMCn74gf6iDcNAJrM5YhTbfWQ0orVTE4u8CIQCngnhQ5NOG56HN54dQPrx/5ppSdc3gcAm0CHdTEJVcmQ==\n"
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n48665820\nCm0abK/q+qL3cRk7T+ReKBF+hk28hsUgHg25AkLuPk0=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiBuksErt2EiGfAFUlWFlhdUWFJbGuIH5jcyREma5aycvgIgKFEfiwH6M42qex8NUNlbxyP3UC3oRMVAg8A5Fpec22U=\n"
                             }
                         },
-                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJiZmJiOWI2M2UwNzJiMjFjNDRhZTIwZGExNGRkOGVmMTRmYThjMGNiNjMyZDkzOTI0ZDVkZWZkNWRiMmVkZWQzIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUUNEcGNxRWEvZzNpdld2YWtRUnJMVXFyeGs0MWlmMXpWSCt4OE9vMFIzLzFRSWhBTWVpdUlWNlEvMXN1MzE3bFA2MCtqamEzdC95c3FaaTcvRE9sV3VGRzVwciIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVlNuZERUVVkyTUU0eWRsVXplVzh4ZG5aYWRGbDBNbWRCV0ZwemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDFxUlhoTlZHdDZUVVJGTWxkb1kwNU5hbFYzVFdwRmVFMVVhekJOUkVVeVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ0UWxrM1Frc3JiVTVwVFZJdmFreElZekZLYldWVFlXNDBkREJ0YUhrMVFtdFRTVEVLT0dsdlRVSXpXbHAyWVUxWFJXRlNiVVIwT1ZWRWFXVXhVR1JKYW5CcVNFVXdabGhWTmpOMFdYVlBXRWxwU2xJNWRVdFBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlVyY25GM0NqaDZOREZPTW5GTGMwWmFNMnN3Y2paU2VWcExWRlJuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNVRm81Y0VOclFRcEJRVkZFUVVWamQxSlJTV2hCVEdNeGMwdFJhamhYYlU5RFRHWjBhQ3MzVm5sMlNqQnRTemd2YjBKTU1rcE1WMlFyTTFwTlYybENSMEZwUWxaRk0xTlhDblpoWVRBeGQwbHJTMlJLY1RKdlR6SnViRnBQUkhZNFYyVTVjbXdyZWpGcWFXUmhSbVpVUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFRWGtLTTJjMVVVNVNXVUk0YVVOMFlsVm1XbkJLUmpSdmRrOXpUME01YTJNeVlTdDNVVUl3U0VWblkzb3dURmN3U1hScFVUVlBPV0pJVjNSelZDOHhaSE5GUXdwTlVVTkhiVE5MVVZFd2IwTllUVnAxWkdWM05XdGhUWEZpVm10WGJHVkZXRkZyUmxCMFoyTnBNR2RMYTIxWVdrVmlNVFp4V0ZrMU5VeE5ka0psZVVoakNtWTBiejBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJmYmEwNDE4YzI5YzZmZjBjMWU3YjNjNjg3MmE4YTYxMWFhYjQ3MjM3M2FkYmRiODMxYjk5NDU2Zjg3NTQ5ODAwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJRkhpSGhWYmFHYmZSQlBJSGF4SEhVZC92bGZENXpMWHA4cTgxc3Q4aTNmZkFpQXcrRXY5RlN1RnFjZ0NlU2xyYTJGSmJGWGNnWk45R2EzRVZRM2w4Wml1M1E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZla05EUVd4WFowRjNTVUpCWjBsVlUwNUtVRVZKY21OaGRHaDNNekV5YTBkRlIyTlVkMWd2WmtSemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDFxUlhsTlJHTXhUa1JKTTFkb1kwNU5hbFYzVFdwRmVVMUVaM2RPUkVrelYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVUzWXpRMlNHMHhUR3gyTTNWSGVtOUpSa28zYnpaeGJYUkJhM2R4VGtWTWJERjFkQzhLZUZoMFZVaHNlV1pMV0VGdk5teFpORGxZWldkSE5sWXlVRWR3T1ZNMWFuSXhZMlpUYVhWR1lYVXZWamxyTldjemFuRlBRMEZZVVhkblowWjNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZIVjBOTENuZG5WRnBXVERjd2RtbFNjVzR4V205eVIzQjRNelpqZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVhkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWprS1FraHpRV1ZSUWpOQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNVR3R0T0RVMFFRcEJRVkZFUVVWbmQxSm5TV2hCVG5WcFIyODRRME5GZFZVNFptZzNlaXRNYUVKUFkzY3lTSGRpZEdWVFYzTkNNRTVITjFkeGRFRmlNVUZwUlVGdlExSm9DbFp1TlhOcWJFaGtXRVphU0dRMmJYbGpjSGxpTldJek1XSkRNMWxwZFZOdWIxQlhNV1pCWTNkRFoxbEpTMjlhU1hwcU1FVkJkMDFFWVVGQmQxcFJTWGdLUVZBNWVWcDRVMjVhTVRScGEzcDJWemhCU21ONVVUaGFkbXRwY2xoa2FrTXJNakpOY1VJeWNWQXhTV2RzU2tGRGEweEdaVVZvZVdwak5TdEZZa1Z2VFFveFowbDNTbXc1UVVoaFpFODNiMmhqZG01NFduSlFXa2h3U3k5elVHUXZXQ3RsYUc5MFJtcDNhM0ZHY0ZWVGEwNVNPRmREVVVwcFlpdHdkSHA1VUVSRENuVnBaRFlLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
                     }
                 ]
             },
             "messageSignature": {
                 "messageDigest": {
                     "algorithm": "SHA2_256",
-                    "digest": "v7ubY+ByshxEriDaFN2O8U+owMtjLZOSTV3v1dsu3tM="
+                    "digest": "+6BBjCnG/wweezxocqimEaq0cjc629uDG5lFb4dUmAA="
                 },
-                "signature": "MEYCIQCDpcqEa/g3ivWvakQRrLUqrxk41if1zVH+x8Oo0R3/1QIhAMeiuIV6Q/1su317lP60+jja3t/ysqZi7/DOlWuFG5pr"
+                "signature": "MEQCIFHiHhVbaGbfRBPIHaxHHUd/vlfD5zLXp8q81st8i3ffAiAw+Ev9FSuFqcgCeSlra2FJbFXcgZN9Ga3EVQ3l8Ziu3Q=="
             }
         }
     },
@@ -84,11 +85,11 @@
             "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
             "verificationMaterial": {
                 "certificate": {
-                    "rawBytes": "MIICzDCCAlOgAwIBAgIUdV+oAWPkrGZOa3JpV8WMpmZ96mgwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwMjExMTkzMDMwWhcNMjUwMjExMTk0MDMwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElEZiw7IOAnNIIRZp40/lVmN1rxDGmLKBwIIrTVkGACO9wHuZwodAPC+YKss3A5PiEBszg969kcZNQqifyMZ9sKOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQULSYI/Jv4m7Hfe4IxCBzcKK4Fg5cwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlPZ92scAAAQDAEYwRAIgMY8Cdah5LqVzI1nSUU7PSk1hD0KrvDLPTmgHsvzVTawCICBQrn3GJNXNoy3VcqY4iis0ehN5g6+4zFa9VPdPFvG+MAoGCCqGSM49BAMDA2cAMGQCMGNCr8o+TGBsKbeAYRY10DUosjAUar7ZpofW9GCptXAy4gqUzrPmC0vieFrywXEgBAIwAdANc0lT5BBVyFInn7lH7FA7p0bTskRvbbTFxLCzQJx2Qt20YviRJcf4HpVoHsES"
+                    "rawBytes": "MIICzTCCAlOgAwIBAgIUCBWax1Yv006eiUrTmVXnVEYP0acwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwMjEyMDc1NDE1WhcNMjUwMjEyMDgwNDE1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVLFuPzDtOjejFwRdg4rACkVZkfQ10PXnoC8+U28wbs73RqyH7az/ArOWDhwvCruZCTOtm2QTWYCK30NDi/6q+KOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUc0Iet3OpFv7Oq6lKxwe/rg2yFgowHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlPkmxwAAAAQDAEYwRAIgFK4/2Od+BPgQZOqIOjCl7m37O9dFR6o8vvSxw3wLaKECICszaphh3ouecV37MD5cNSrC9OMoOvVUD1tL51NIygISMAoGCCqGSM49BAMDA2gAMGUCMQCNuzhin8H0+q2qxODgGrsKMpaSmK20VJxjmW+sEaEZzKROThaHevYwgFKOVFD1uj8CMBgy22e4sm2yW2tScetkOuYwgU3sSUycXRP9pKr9Gllfg9lOFlXC6/vnmvBuPRRjsA=="
                 },
                 "tlogEntries": [
                     {
-                        "logIndex": "170370868",
+                        "logIndex": "170570053",
                         "logId": {
                             "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
                         },
@@ -96,45 +97,46 @@
                             "kind": "hashedrekord",
                             "version": "0.0.1"
                         },
-                        "integratedTime": "1739302231",
+                        "integratedTime": "1739346856",
                         "inclusionPromise": {
-                            "signedEntryTimestamp": "MEYCIQCPm9xRtKLab8OOWfOXsO7NSO77URiu8YQbBUiiOHWBegIhALPPZglfn/zpr8G3mQ7QxNJtxmWUpUhPs5m5arqXmvaf"
+                            "signedEntryTimestamp": "MEYCIQCGqYfCnbihbWn8mvWbiVe5x9xA/0Mvy2VRBnFm5E8ZZgIhAO6zmjkYA67Ttb7JKF5nn68KMvWi5MTzR+8o9xVq136S"
                         },
                         "inclusionProof": {
-                            "logIndex": "48466606",
-                            "rootHash": "lizw2Hmpib7FPBOAW76VWENWqnbGr+4kbU+lq22pCys=",
-                            "treeSize": "48466608",
+                            "logIndex": "48665791",
+                            "rootHash": "HzxfBCv2yi4J8G+S7TgoiMNBBo/wSkRjGDJfNOVUcTs=",
+                            "treeSize": "48665792",
                             "hashes": [
-                                "zLP6bInnqEpmw0FnrRIaGcmsE0Ai4K8icuQrDnMhdYo=",
-                                "4/jcpSkOkP2ZSPmn3TuitxeNPe9iIxxbMwzEFsLTl+M=",
-                                "WPQch8qM/03Hf582Vr4RQ/hGEMOjcNkq0lnuQyNGNrM=",
-                                "VJ4gzGYZi3JU+zruGMGkWALGX4Syl8g8pFsWlMDHOxw=",
-                                "Rk7Pu5pdKc4P3w4jRMcBI27yyva8bZdMZ3OhG95wo/E=",
-                                "NIOOqMSKdAoUUw+pt7mqUuxMeSv/F7SY8bW1PoVnCqs=",
-                                "uJeS9vHrt8GsXkJ3K2qDiitgQRmxdxZQDEpg8ZU88/w=",
-                                "AqQkj8KhPFRow/yeWhJ6qfkgA5M98xQ2O4IAHsQROvI=",
-                                "Tq7UWnwDGysF2R873ZsZ8MBhytL8JyQDuyeDr3/gCZc=",
-                                "yQk3XGa+J/GjPzdB1VYsHiVqAYpxymG1eW36uATfM2k=",
-                                "dKc+Z0lFxSZtZFebHmUcz/bS+EbsE1qMLGw8B/jxcRE=",
+                                "b0yDjzNitZJIGTblWLhs4yUCBz6CKSng8isTxSgbsVE=",
+                                "dkJ2Yt1bEtBmpXpRN3vSmk+6+1j8GsOFEUA9iyueWhk=",
+                                "i1ABh9Dx8meNOBCr/HhTSupqNYK0LI+NnFjXmDfEgnY=",
+                                "MegLwopuwueYsc+JjT6t3LKiOJmtE0MguZsVB71COH0=",
+                                "FT+AWm/ITpPN+fIVrNXLPTjNvmfTVoGQfCV+uE6gZ8w=",
+                                "kRkMXhEDVcanV+ajODgw+9wD30fMQgV1vmvCfUV8ba0=",
+                                "6Z0kSTNv87FgCP6fBI6QTIRs0ABTmLD9tgAbSWRDRr0=",
+                                "p39Aj7k63Y8N82q5GXzhIzuZSex0HZN+9xq7U1Sxdp4=",
+                                "jhYil8zet/V88Ox8NV66V1iBkETlEJ2qH+SXo+kfMb0=",
+                                "Z/HAKVPPWMW9bRNxiWSaI+beB8FjcG/QYDqBuAZMTsY=",
+                                "cgbhJqDRiWT+2XKIQ9ch9WJ+6uwysr3Vn01jUW3nyv0=",
+                                "0NILEMXlPNU3cLx3pWSpe/u8BfMuXFyP+6HIsWDtkAU=",
                                 "3G1CfELRgkrpGc7BJBsecW/HvOojsTHpl40WsoH/3A0=",
                                 "Zse3BPkR/cJv62LvVuiDH+EpgIE5v3V3qXdG8HQFf1A=",
                                 "jU9+tgjTIKUYGeU7T7RjqyL+F+gFV9tCdwX2GZ1UtQs=",
                                 "vemyaMj0Na1LMjbB/9Dmkq8T+jAb3o+yCESgAayUABU="
                             ],
                             "checkpoint": {
-                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n48466608\nlizw2Hmpib7FPBOAW76VWENWqnbGr+4kbU+lq22pCys=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAt/5Zxd/Y7iPfJE57Axhh9OuA2z9QoBlH2osOWg5r4FgIgbPEHLKkC2jTqX17rYnHwHihqoiV4gRWkTYInI0HsWcc=\n"
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n48665792\nHzxfBCv2yi4J8G+S7TgoiMNBBo/wSkRjGDJfNOVUcTs=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEA3ZglJ4aYKUNaTJ96mujk5pcgWAj6iiwpmuUtpKIepGQCIGsrkTWsS2nFwjAv95ctdnJZK7cSvUMf+milS4alGlu9\n"
                             }
                         },
-                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJlNDJkOTFkNmRkMzAxNmJmYzJmNmY5NmMxMTI5YjQwY2E2ZDhmNmUxYmYzYjMwYTExZGUxNDZkOTMwZjQzYjMyIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUNyRit4TDlRL0NjYWJHbGRqZ1BTck5ScFZnOHNWWjNaOWVJS1l2ZXdjemR3SWdabGhyUEhwSkN3MW95anZEMjhWY3oxaG1mNW92SXBmTFJITDRQbzl3VHRRPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4UFowRjNTVUpCWjBsVlpGWXJiMEZYVUd0eVIxcFBZVE5LY0ZZNFYwMXdiVm81Tm0xbmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDFxUlhoTlZHdDZUVVJOZDFkb1kwNU5hbFYzVFdwRmVFMVVhekJOUkUxM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZzUlZwcGR6ZEpUMEZ1VGtsSlVscHdOREF2YkZadFRqRnllRVJIYlV4TFFuZEpTWElLVkZaclIwRkRUemwzU0hWYWQyOWtRVkJESzFsTGMzTXpRVFZRYVVWQ2MzcG5PVFk1YTJOYVRsRnhhV1o1VFZvNWMwdFBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZNVTFsSkNpOUtkalJ0TjBobVpUUkplRU5DZW1OTFN6UkdaelZqZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNVRm81TW5OalFRcEJRVkZFUVVWWmQxSkJTV2ROV1RoRFpHRm9OVXh4Vm5wSk1XNVRWVlUzVUZOck1XaEVNRXR5ZGtSTVVGUnRaMGh6ZG5wV1ZHRjNRMGxEUWxGeWJqTkhDa3BPV0U1dmVUTldZM0ZaTkdscGN6QmxhRTQxWnpZck5IcEdZVGxXVUdSUVJuWkhLMDFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbU5CVFVkUlEwMUhUa01LY2podksxUkhRbk5MWW1WQldWSlpNVEJFVlc5emFrRlZZWEkzV25CdlpsYzVSME53ZEZoQmVUUm5jVlY2Y2xCdFF6QjJhV1ZHY25sM1dFVm5Ra0ZKZHdwQlpFRk9ZekJzVkRWQ1FsWjVSa2x1Ympkc1NEZEdRVGR3TUdKVWMydFNkbUppVkVaNFRFTjZVVXA0TWxGME1qQlpkbWxTU21ObU5FaHdWbTlJYzBWVENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3NGU4M2YyNmRlMWU0ZmI5ZWVmMWI1NjQ5MmNmZjkyNTA4ODM0YmI3MWFjMTNmNWM1ODA0MzhjZTlmMDkzNjgyIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJQVlIaGJLVVNTZldtMmNqV2hWYmhtUXdEUTdtR0lpcGdCVEpKaXFrdEtmdEFpRUE2VUszY3huRE5iZ0g1QnYzalBLanZzL2c5YjRrT1NNVTEvTUs2cmN1RklBPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4UFowRjNTVUpCWjBsVlEwSlhZWGd4V1hZd01EWmxhVlZ5VkcxV1dHNVdSVmxRTUdGamQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDFxUlhsTlJHTXhUa1JGTVZkb1kwNU5hbFYzVFdwRmVVMUVaM2RPUkVVeFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZXVEVaMVVIcEVkRTlxWldwR2QxSmtaelJ5UVVOclZscHJabEV4TUZCWWJtOURPQ3NLVlRJNGQySnpOek5TY1hsSU4yRjZMMEZ5VDFkRWFIZDJRM0oxV2tOVVQzUnRNbEZVVjFsRFN6TXdUa1JwTHpaeEswdFBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZqTUVsbENuUXpUM0JHZGpkUGNUWnNTM2gzWlM5eVp6SjVSbWR2ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNVR3R0ZUhkQlFRcEJRVkZFUVVWWmQxSkJTV2RHU3pRdk1rOWtLMEpRWjFGYVQzRkpUMnBEYkRkdE16ZFBPV1JHVWpadk9IWjJVM2gzTTNkTVlVdEZRMGxEYzNwaGNHaG9Dak52ZFdWalZqTTNUVVExWTA1VGNrTTVUMDF2VDNaV1ZVUXhkRXcxTVU1SmVXZEpVMDFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbWRCVFVkVlEwMVJRMDRLZFhwb2FXNDRTREFyY1RKeGVFOUVaMGR5YzB0TmNHRlRiVXN5TUZaS2VHcHRWeXR6UldGRlducExVazlVYUdGSVpYWlpkMmRHUzA5V1JrUXhkV280UXdwTlFtZDVNakpsTkhOdE1ubFhNblJUWTJWMGEwOTFXWGRuVlROelUxVjVZMWhTVURsd1MzSTVSMnhzWm1jNWJFOUdiRmhETmk5MmJtMTJRblZRVWxKcUNuTkJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
                     }
                 ]
             },
             "messageSignature": {
                 "messageDigest": {
                     "algorithm": "SHA2_256",
-                    "digest": "5C2R1t0wFr/C9vlsESm0DKbY9uG/OzChHeFG2TD0OzI="
+                    "digest": "dOg/Jt4eT7nu8bVkks/5JQiDS7cawT9cWAQ4zp8JNoI="
                 },
-                "signature": "MEUCIQCrF+xL9Q/CcabGldjgPSrNRpVg8sVZ3Z9eIKYvewczdwIgZlhrPHpJCw1oyjvD28Vcz1hmf5ovIpfLRHL4Po9wTtQ="
+                "signature": "MEUCIAYHhbKUSSfWm2cjWhVbhmQwDQ7mGIipgBTJJiqktKftAiEA6UK3cxnDNbgH5Bv3jPKjvs/g9b4kOSMU1/MK6rcuFIA="
             }
         }
     },


### PR DESCRIPTION
See: https://www.python.org/downloads/release/python-3140a5/ 

> This release initially contained source tarballs that didn't match the final v3.14.0a5 Git tag. Around 2025-02-12 0815 UTC, the source tarballs were replaced with the correct versions. This happened because this release took three attempts due to a bug that failed the Windows PGO builds, and the release manager accidentally uploaded the source tarballs from the second attempt.

Also switches us to uv for the fetcher, which should be a decent bit faster.