### PR TITLE
fixup fetcher, add recent releases

### DIFF
--- a/versions/3.10.18.json
+++ b/versions/3.10.18.json
@@ -1,0 +1,150 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tgz",
+        "sha256": "1b19ab802518eb36a851f5ddef571862c7a31ece533109a99df6d5af0a1ceb99",
+        "release_url": "https://www.python.org/downloads/release/python-31018/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "035ff701ad6c9183dc4c6de817924892",
+            "File Size": "24.7\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tgz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tgz.sigstore"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlKgAwIBAgIUQylwFYOArXjhZaCYl3nLuAQJzxgwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTg1ODIxWhcNMjUwNjAzMTkwODIxWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6IgyRtCXVOsACJ65WzZZHM/JL3wYBUA3swwHjBzUs3RMiYugp7hG+T7iNjkG3C5mk0a3IUAspvHRBsaLLFGEmaOCAXEwggFtMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUV0Nh98LXFrZ0iVB7xfxR0ZXPizAwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wIgYDVR0RAQH/BBgwFoEUcGFibG9nc2FsQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXNyiqAgAABAMARjBEAiACaPiNOnkB+m5eRJ0T20kny9WJImUSl4Pbg+q/qF2/vQIgGoDX+J/wAyUETEeCD+GCyZsNjCaLz4LTMVs7HRE6Zv0wCgYIKoZIzj0EAwMDZwAwZAIwAvpipaWUvF0VMRqlbhl1jCAmUYxEIB0Yr2SA0QedPtaaVgeflg7X8bSAc1BiT8xCAjBRnJP3N1FUJSHv0oAJ9BwSkfrHOIRE6nYIHyCsq4c/6RpUPzyGU2YWIa7wlsP/dhI="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228919669",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748977101",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQD+FO/LN+BDxm8yBcXw7EwI1K/hoqxkZ7/gQ3/Tq6gzWgIhAJYyNp41qg1PCdpS1zG4L33HFacv6l+larnBWJnvzCVB"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107015407",
+                            "rootHash": "VAR+muJuUOHj0vQkhkkVfjSokMnuDNFoi6us0I4FAWA=",
+                            "treeSize": "107015416",
+                            "hashes": [
+                                "InxjDYUb89MzhNRtjBAFrJbYqNSS1Hb9v2X9cxThDxE=",
+                                "zqzryNk1GD8eh2vZc9tRMEWGnzc4yftY60XJmPN3LPg=",
+                                "B0dt+TwM7AQ5ya4KapZ/kKD3G47zxwMg8B1GOnZ0Fn8=",
+                                "MP416ACIkHNhPZ81TA5YRpcGVGWePPzH/PpORC/vBms=",
+                                "y3L+bB30piON85RSBJv37uHvijR0QA68WheP/OOVhtc=",
+                                "hktXBTugPsmIJ82IfBaarVAaK3GXGZOGqfXK7t8GwzI=",
+                                "XuHx0QIy19KSdr0JXp2oH/xfFIut7o4aYSOUdSNvdA0=",
+                                "ruwZJ2bOX418aalsfurfJTIQCl0/2cZOuvdymqS/kfQ=",
+                                "m/WZEVH9CTs0KJcGZIdK4CVc1WENSbb9gjFrdzj5kYI=",
+                                "MRAzh2spHQbvIBIISBBvo0zc0n73qn6TIJ5ur8P4K/8=",
+                                "tuZDuieL5jtYIFu4Miyh8eBdvmmkGD1LcMTrLs7j/ZE=",
+                                "kbUClUnkU0UJZhuQHiwkFFDXdat+8DImNUFMe+bn0Q4=",
+                                "WdQbyoFfuhZe2IciO+mhgtPi9ev0pSFpkBr7XCWylqQ=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107015416\nVAR+muJuUOHj0vQkhkkVfjSokMnuDNFoi6us0I4FAWA=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEA/mAr0x7LDiGoPrvVqg2x38fKg3EBZz6LShpL+7uepNECIQCni/O49i0bZcyZ4UtT+evEoPGV2Fqzxd1N4RUQrOVxIA==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIxYjE5YWI4MDI1MThlYjM2YTg1MWY1ZGRlZjU3MTg2MmM3YTMxZWNlNTMzMTA5YTk5ZGY2ZDVhZjBhMWNlYjk5In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUURxcHRISDFTRGhEczR0SFFTQ1UwdElrUU5aR3ZxeFhtSFBFR04wS0RWWXBRSWdTYXRacWpUbWNUT1M3ZjZJNm5KMytHU0RiUTF0KzlXdEU2RkV0UG1waEhzPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4TFowRjNTVUpCWjBsVlVYbHNkMFpaVDBGeVdHcG9XbUZEV1d3emJreDFRVkZLZW5obmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHY3hUMFJKZUZkb1kwNU5hbFYzVG1wQmVrMVVhM2RQUkVsNFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVUyU1dkNVVuUkRXRlpQYzBGRFNqWTFWM3BhV2toTkwwcE1NM2RaUWxWQk0zTjNkMGdLYWtKNlZYTXpVazFwV1hWbmNEZG9SeXRVTjJsT2FtdEhNME0xYldzd1lUTkpWVUZ6Y0haSVVrSnpZVXhNUmtkRmJXRlBRMEZZUlhkblowWjBUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZXTUU1b0NqazRURmhHY2xvd2FWWkNOM2htZUZJd1dsaFFhWHBCZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBsbldVUldVakJTUVZGSUwwSkNaM2RHYjBWVlkwZEdhV0pIT1c1ak1rWnpVVWhDTldSSGFIWmlhVFYyWTIxamQwdFJXVXRMZDFsQ1FrRkhSQXAyZWtGQ1FWRlJZbUZJVWpCalNFMDJUSGs1YUZreVRuWmtWelV3WTNrMWJtSXlPVzVpUjFWMVdUSTVkRTFEYzBkRGFYTkhRVkZSUW1jM09IZEJVV2RGQ2toUmQySmhTRkl3WTBoTk5reDVPV2haTWs1MlpGYzFNR041Tlc1aU1qbHVZa2RWZFZreU9YUk5TVWRLUW1kdmNrSm5SVVZCWkZvMVFXZFJRMEpJYzBVS1pWRkNNMEZJVlVFelZEQjNZWE5pU0VWVVNtcEhValJqYlZkak0wRnhTa3RZY21wbFVFc3pMMmcwY0hsblF6aHdOMjgwUVVGQlIxaE9lV2x4UVdkQlFRcENRVTFCVW1wQ1JVRnBRVU5oVUdsT1QyNXJRaXR0TldWU1NqQlVNakJyYm5rNVYwcEpiVlZUYkRSUVltY3JjUzl4UmpJdmRsRkpaMGR2UkZnclNpOTNDa0Y1VlVWVVJXVkRSQ3RIUTNsYWMwNXFRMkZNZWpSTVZFMVdjemRJVWtVMlduWXdkME5uV1VsTGIxcEplbW93UlVGM1RVUmFkMEYzV2tGSmQwRjJjR2tLY0dGWFZYWkdNRlpOVW5Gc1ltaHNNV3BEUVcxVldYaEZTVUl3V1hJeVUwRXdVV1ZrVUhSaFlWWm5aV1pzWnpkWU9HSlRRV014UW1sVU9IaERRV3BDVWdwdVNsQXpUakZHVlVwVFNIWXdiMEZLT1VKM1UydG1ja2hQU1ZKRk5tNVpTVWg1UTNOeE5HTXZObEp3VlZCNmVVZFZNbGxYU1dFM2QyeHpVQzlrYUVrOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "GxmrgCUY6zaoUfXd71cYYsejHs5TMQmpnfbVrwoc65k="
+                },
+                "signature": "MEUCIQDqptHH1SDhDs4tHQSCU0tIkQNZGvqxXmHPEGN0KDVYpQIgSatZqjTmcTOS7f6I6nJ3+GSDbQ1t+9WtE6FEtPmphHs="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tar.xz",
+        "sha256": "ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f",
+        "release_url": "https://www.python.org/downloads/release/python-31018/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "14ea0982a7dd4dbfc3f50537c723df41",
+            "File Size": "18.7\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tar.xz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tar.xz.sigstore"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlOgAwIBAgIUPPj8WFgcPzKI0f+pcaxc3TPA/yswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTg1ODI4WhcNMjUwNjAzMTkwODI4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4NqgXmbx5LR/ICb4FcCE0psZ0nEPhnhmk36DOselqJIUA54Dj0SKcFUP3wbmqi9h9bo7ZqbQ5HTZR0ditz16KKOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU91EDPL5bqZeofhdNBEBL98Ga+MEwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wIgYDVR0RAQH/BBgwFoEUcGFibG9nc2FsQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXNyjEogAABAMARzBFAiBenFTetr0d9XKM2FxuhUPv7YJVxt4F5reAl9D4IOX2JwIhAOULSuk4H79udCf1i4QEIPCrs3oEV3u+VpJ9GTC2Y+/mMAoGCCqGSM49BAMDA2cAMGQCMGGrDPAeA+zuXcHOmXGsqPX274/sjglPqkuXX8wI1JwDUoT5mN7ZZpAJX8XAQQAixwIwfk+a9VmWcY0I1UuAu+NuRRkNQCofemUeEuzhWyK1Yn5G+DcuXVf7lNlwC6awM0mb"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228919874",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748977108",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIBlZWCgOoVzS+qS/YuAKZFDbO/cyOLxdRdDRFQVrjbfzAiEAvs5r5K/zZEJJE5bh/OFQPTex7Hj9OzJ8SQtvX2bATVk="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107015612",
+                            "rootHash": "SCbCVVGttK0oajRjYxDAulUQEOL1nRy9KG6JbVMfe88=",
+                            "treeSize": "107015615",
+                            "hashes": [
+                                "1jQZ0U0iztYR47T7VqVQL/XmQ1kOJ9VGJAlEV7S12Rk=",
+                                "nzFzeKP8TFHjIx2Mf5E5RHDnftKz14VXcXGOv6TjP2U=",
+                                "rYdthRwegf6R59Jn79y56HZlg/HgWGq2ThwABpgzIx8=",
+                                "itoQl5XnazIM1MaE0xAHfTyJuXWLosPRHBX6LOyQZqw=",
+                                "m4vF5qDZ/VpszDAF6BpkLLL9mJUrMqTnDGBzbP1+mAA=",
+                                "aPbPdtUCj7gO3JjjsuOf+HO0RD3cth0ZCf7GBkev2jA=",
+                                "F1AHv3JuUWYZTcWLZFEo2qDYsdVdytSXRmZu4tASPAk=",
+                                "jhwwkSRTGiVvY/O6FZ9c4ASOhW4Uktv0K324Xmy4V/k=",
+                                "m/WZEVH9CTs0KJcGZIdK4CVc1WENSbb9gjFrdzj5kYI=",
+                                "MRAzh2spHQbvIBIISBBvo0zc0n73qn6TIJ5ur8P4K/8=",
+                                "tuZDuieL5jtYIFu4Miyh8eBdvmmkGD1LcMTrLs7j/ZE=",
+                                "kbUClUnkU0UJZhuQHiwkFFDXdat+8DImNUFMe+bn0Q4=",
+                                "WdQbyoFfuhZe2IciO+mhgtPi9ev0pSFpkBr7XCWylqQ=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107015615\nSCbCVVGttK0oajRjYxDAulUQEOL1nRy9KG6JbVMfe88=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAC5UJXNKStXDw/L3DlSxscdhpQvVI3Ann4US9sFgT0mAIgJw8zaZc5WMKv1tIRBEUSw1lTjeEO69ypVTwS3MGF7MQ=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJhZTY2NWJjNjc4YWJkOWFiNmE2ZTE1NzNkMjQ4MTYyNWE1MzcxOWJjNTE3ZTlhNjM0ZWQyYjlmZWZhZTM4MTdmIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQ3RudW1SZHlqbUVZaHV3MlpNTWdBZFpBeXYvcjVnSjhHbnFUWTBlTS9yNUFpQklQM2pGQWN6TXFhY0N5RE9kMkFKU0VyNmEwSTQxcnRwUHJCRUJMc1ArU0E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4UFowRjNTVUpCWjBsVlVGQnFPRmRHWjJOUWVrdEpNR1lyY0dOaGVHTXpWRkJCTDNsemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHY3hUMFJKTkZkb1kwNU5hbFYzVG1wQmVrMVVhM2RQUkVrMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVUwVG5GbldHMWllRFZNVWk5SlEySTBSbU5EUlRCd2Mxb3dia1ZRYUc1b2JXc3pOa1FLVDNObGJIRktTVlZCTlRSRWFqQlRTMk5HVlZBemQySnRjV2s1YURsaWJ6ZGFjV0pSTlVoVVdsSXdaR2wwZWpFMlMwdFBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlU1TVVWRUNsQk1OV0p4V21WdlptaGtUa0pGUWt3NU9FZGhLMDFGZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBsbldVUldVakJTUVZGSUwwSkNaM2RHYjBWVlkwZEdhV0pIT1c1ak1rWnpVVWhDTldSSGFIWmlhVFYyWTIxamQwdFJXVXRMZDFsQ1FrRkhSQXAyZWtGQ1FWRlJZbUZJVWpCalNFMDJUSGs1YUZreVRuWmtWelV3WTNrMWJtSXlPVzVpUjFWMVdUSTVkRTFEYzBkRGFYTkhRVkZSUW1jM09IZEJVV2RGQ2toUmQySmhTRkl3WTBoTk5reDVPV2haTWs1MlpGYzFNR041Tlc1aU1qbHVZa2RWZFZreU9YUk5TVWRMUW1kdmNrSm5SVVZCWkZvMVFXZFJRMEpJZDBVS1pXZENORUZJV1VFelZEQjNZWE5pU0VWVVNtcEhValJqYlZkak0wRnhTa3RZY21wbFVFc3pMMmcwY0hsblF6aHdOMjgwUVVGQlIxaE9lV3BGYjJkQlFRcENRVTFCVW5wQ1JrRnBRbVZ1UmxSbGRISXdaRGxZUzAweVJuaDFhRlZRZGpkWlNsWjRkRFJHTlhKbFFXdzVSRFJKVDFneVNuZEphRUZQVlV4VGRXczBDa2czT1hWa1EyWXhhVFJSUlVsUVEzSnpNMjlGVmpOMUsxWndTamxIVkVNeVdTc3ZiVTFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbU5CVFVkUlEwMUhSM0lLUkZCQlpVRXJlblZZWTBoUGJWaEhjM0ZRV0RJM05DOXphbWRzVUhGcmRWaFlPSGRKTVVwM1JGVnZWRFZ0VGpkYVduQkJTbGc0V0VGUlVVRnBlSGRKZHdwbWF5dGhPVlp0VjJOWk1Fa3hWWFZCZFN0T2RWSlNhMDVSUTI5bVpXMVZaVVYxZW1oWGVVc3hXVzQxUnl0RVkzVllWbVkzYkU1c2QwTTJZWGROTUcxaUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "rmZbxnir2atqbhVz0kgWJaU3GbxRfppjTtK5/vrjgX8="
+                },
+                "signature": "MEQCICtnumRdyjmEYhuw2ZMMgAdZAyv/r5gJ8GnqTY0eM/r5AiBIP3jFAczMqacCyDOd2AJSEr6a0I41rtpPrBEBLsP+SA=="
+            }
+        }
+    }
+]

--- a/versions/3.11.13.json
+++ b/versions/3.11.13.json
@@ -1,0 +1,142 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tgz",
+        "sha256": "0f1a22f4dfd34595a29cf69ee7ea73b9eff8b1cc89d7ab29b3ab0ec04179dad8",
+        "release_url": "https://www.python.org/downloads/release/python-31113/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "8abf1b1a9237f01b54572e2ecb246262",
+            "File Size": "25.4\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tgz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tgz.sigstore"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlKgAwIBAgIUUPgRcoo8ZadCDND58+d/J6y4NQgwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTkyNzI4WhcNMjUwNjAzMTkzNzI4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU+4wGCv9JuxCMsgVzbWjv+4T6zZK8+LKUPLFtAj0KuGSSJ2tJ57+SbxSnNwcrz53//T8KRhYNiz6QktSer7/d6OCAXEwggFtMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUgRMms1LngVkE+yVWJ7tV93Beu1wwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wIgYDVR0RAQH/BBgwFoEUcGFibG9nc2FsQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN0NTPAAABAMARjBEAiBMDlGKJy2lL4oiVmosCaAa5ZbBld+Qjexl6lS4DiPa0AIgX+O2HVjPICCJzRuvnWx5cJkRvs74ru5ewBhwsvHTJx8wCgYIKoZIzj0EAwMDZwAwZAIwNj4viLz13zHkyras0g4oVftv7WYCq2XNGg5Fp3eT1fEZMHFuqJsUkuSDhy3+QNPIAjAWagdiQoYwIzvc0XizVbtOj0lYdx20AMk35PHyVFSGJJSs9TcUlladfPgHe49ye/w="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228953844",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748978849",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQD1hhO/RnD06AWsz+ffUymAV1GcVBxM61XVpGN4feDsJwIgdJmAE3a/AwtvYgFkZvK+PvJoNjt3/ujmqUAcFH9CQhc="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107049582",
+                            "rootHash": "r5gegonI3dFCgeI5j2r2yPoH/Der5jmIU7bH9RDR4Vs=",
+                            "treeSize": "107049583",
+                            "hashes": [
+                                "TQ+pwzceDptObX0SZyZxy/ryt1rvFyMz185kBum3uLQ=",
+                                "jXDuGpKBgUud1UqxfZe2V9jEiJDcQvLQB67MueldwN4=",
+                                "I/JtHhb/pfX1SEmyy5N8SBNcFHMI9gQoKtpnRpO3B0A=",
+                                "qw5ajrrr/J/5iWRQaX5LiWvOg+r5qsOSAUUi9L0e96o=",
+                                "gyeYUZHCx4vqimiTowpu+NNjcIJEZ8xgOB8DNlkAkhY=",
+                                "bCrkgWpJ8MBic+mIfCRsKi+5XAMqgM8Lc6G0LLfzZ7M=",
+                                "4iwdOrGkcqdN0qqZUx/gv8a8qpLMqVj8aXRVmhQ558c=",
+                                "mAX/zvx1jR0ujLtDApsQpHyxmoDGidClHMOn0BX1aQA=",
+                                "u5LKLBPTYgXZg0fBi6/8LuEeNy3EBAxJF0AkkB4Co6E=",
+                                "SPUVncwJRVX/n/RICCYqLpAzraqx7S0eMdXRr1RLRgg=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107049583\nr5gegonI3dFCgeI5j2r2yPoH/Der5jmIU7bH9RDR4Vs=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiB0UQiu5Ks8UZOBVmrbZ9uTlQvrRs0twMHd1VlgUcGUNQIhAIR5ir1xTFNfImUis0rjc2hmcE2AlVv+W87AKkh/B/ZP\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIwZjFhMjJmNGRmZDM0NTk1YTI5Y2Y2OWVlN2VhNzNiOWVmZjhiMWNjODlkN2FiMjliM2FiMGVjMDQxNzlkYWQ4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUUMzeitTTzgvR2dVYVR5Y0UzZVY2TUlhK09NeTZVaUpUR0paN0xjZVNVT0tBSWhBTVRqbG0veVJmUzB4VHJUK2tlQVpBd3pXY3c0MlNYTXFqb3NMMUdCNE9tVyIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4TFowRjNTVUpCWjBsVlZWQm5VbU52YnpoYVlXUkRSRTVFTlRnclpDOUtObmswVGxGbmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHdDVUbnBKTkZkb1kwNU5hbFYzVG1wQmVrMVVhM3BPZWtrMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZWS3pSM1IwTjJPVXAxZUVOTmMyZFdlbUpYYW5Zck5GUTJlbHBMT0N0TVMxVlFURVlLZEVGcU1FdDFSMU5UU2pKMFNqVTNLMU5pZUZOdVRuZGpjbm8xTXk4dlZEaExVbWhaVG1sNk5sRnJkRk5sY2pjdlpEWlBRMEZZUlhkblowWjBUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZuVWsxdENuTXhURzVuVm10RkszbFdWMG8zZEZZNU0wSmxkVEYzZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBsbldVUldVakJTUVZGSUwwSkNaM2RHYjBWVlkwZEdhV0pIT1c1ak1rWnpVVWhDTldSSGFIWmlhVFYyWTIxamQwdFJXVXRMZDFsQ1FrRkhSQXAyZWtGQ1FWRlJZbUZJVWpCalNFMDJUSGs1YUZreVRuWmtWelV3WTNrMWJtSXlPVzVpUjFWMVdUSTVkRTFEYzBkRGFYTkhRVkZSUW1jM09IZEJVV2RGQ2toUmQySmhTRkl3WTBoTk5reDVPV2haTWs1MlpGYzFNR041Tlc1aU1qbHVZa2RWZFZreU9YUk5TVWRLUW1kdmNrSm5SVVZCWkZvMVFXZFJRMEpJYzBVS1pWRkNNMEZJVlVFelZEQjNZWE5pU0VWVVNtcEhValJqYlZkak0wRnhTa3RZY21wbFVFc3pMMmcwY0hsblF6aHdOMjgwUVVGQlIxaE9NRTVVVUVGQlFRcENRVTFCVW1wQ1JVRnBRazFFYkVkTFNua3liRXcwYjJsV2JXOXpRMkZCWVRWYVlrSnNaQ3RSYW1WNGJEWnNVelJFYVZCaE1FRkpaMWdyVHpKSVZtcFFDa2xEUTBwNlVuVjJibGQ0TldOS2ExSjJjemMwY25VMVpYZENhSGR6ZGtoVVNuZzRkME5uV1VsTGIxcEplbW93UlVGM1RVUmFkMEYzV2tGSmQwNXFOSFlLYVV4Nk1UTjZTR3Q1Y21Gek1HYzBiMVptZEhZM1YxbERjVEpZVGtkbk5VWndNMlZVTVdaRldrMUlSblZ4U25OVmEzVlRSR2g1TXl0UlRsQkpRV3BCVndwaFoyUnBVVzlaZDBsNmRtTXdXR2w2Vm1KMFQyb3diRmxrZURJd1FVMXJNelZRU0hsV1JsTkhTa3BUY3psVVkxVnNiR0ZrWmxCblNHVTBPWGxsTDNjOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "Dxoi9N/TRZWinPae5+pzue/4scyJ16sps6sOwEF52tg="
+                },
+                "signature": "MEYCIQC3z+SO8/GgUaTycE3eV6MIa+OMy6UiJTGJZ7LceSUOKAIhAMTjlm/yRfS0xTrT+keAZAwzWcw42SXMqjosL1GB4OmW"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tar.xz",
+        "sha256": "8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a",
+        "release_url": "https://www.python.org/downloads/release/python-31113/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "ec39a8018b9eedf6f0edeb44533bd279",
+            "File Size": "19.2\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tar.xz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tar.xz.sigstore"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlSgAwIBAgIUfnOGm4U1QCsCXWiDvPy5Tgni2HUwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTkyNzM1WhcNMjUwNjAzMTkzNzM1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpTsf/wrCdu4Domf4WOtO4CLkj51wmj4iesYv5N6DYhghPjqQFwGYI9gFc/WX6QMIWh5YHU2NGxrmM7KfbAYzz6OCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUkQ2/O4Fivj1bTq7NTQczm1RdtYAwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wIgYDVR0RAQH/BBgwFoEUcGFibG9nc2FsQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN0NwGwAABAMASDBGAiEA6pD8PjS+5z2SQre/NS/wOdFSjVMsxvtfF6A1jg+1T3YCIQDC44S/Z3c0dNddM7EkE+A3j7Vft3hqRUoFkNe4U6g5qTAKBggqhkjOPQQDAwNoADBlAjA6lBI2r3KCZFc+2affpH3S3Xj3gMOKh8Lr5Z7TgkGp3Q6QsnExGmJJ0leXhqH6rQkCMQDfxk/6DyhbO7KTrIUfmrbZoa7dV75cresJS69Xk67XN57qsqY52DZj9o4fbUIw4ro="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228953871",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748978856",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQC9nXmfcRqyOL2Zmw1zI7+kulTbmDE3Yfzew81mXJGU4QIgF8Uhdg2uzttSA6erOuEchX68PCyJ0cVFHE0XJX2+ZfE="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107049609",
+                            "rootHash": "Ilofw5POqC/C3zqfrdMQP1DyhNW+UfB9fHdjrbK6qaM=",
+                            "treeSize": "107049610",
+                            "hashes": [
+                                "AcD1iyjU7nuIPqAq29ynz7PEdq6zPXglj6e2tkH+/do=",
+                                "1BNDCN01B3dbUo/TfLaQgKIYTvPyrkcrHKd69GxuF2E=",
+                                "t59A0CV2pHM2S9AgZgcEA6FbXhgNZGo0jMRIXHiqsJ0=",
+                                "bCrkgWpJ8MBic+mIfCRsKi+5XAMqgM8Lc6G0LLfzZ7M=",
+                                "4iwdOrGkcqdN0qqZUx/gv8a8qpLMqVj8aXRVmhQ558c=",
+                                "mAX/zvx1jR0ujLtDApsQpHyxmoDGidClHMOn0BX1aQA=",
+                                "u5LKLBPTYgXZg0fBi6/8LuEeNy3EBAxJF0AkkB4Co6E=",
+                                "SPUVncwJRVX/n/RICCYqLpAzraqx7S0eMdXRr1RLRgg=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107049610\nIlofw5POqC/C3zqfrdMQP1DyhNW+UfB9fHdjrbK6qaM=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAjtzTnsnrGx0G3Dg99s89cPUh6EA+cxkicQ9j4qYU60wCIQCKcAL4kdakbq2JrBVgk7bRNf3FoJRrEI6SCjv16f7Crg==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI4ZmI1ZjlmYmM3NjA5ZmE4MjJjYjMxNTQ5ODg0NTc1ZGI3ZmQ5NjU3Y2JmZmI4OTUxMGI1ZDc5NzU5NjNhODNhIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUM5Q1JZRjNSWGUzdDNxQlBJd2UrR3pMMTJCOXVLTjIrRFpWa2JjZW1FTS93SWdPMDFKaVhnbUJxZEN5RVhoM05JUEt5QlRBb2hpcjZHTkhZdXhiSUxKNDlRPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVlptNVBSMjAwVlRGUlEzTkRXRmRwUkhaUWVUVlVaMjVwTWtoVmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHdDVUbnBOTVZkb1kwNU5hbFYzVG1wQmVrMVVhM3BPZWsweFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ3VkhObUwzZHlRMlIxTkVSdmJXWTBWMDkwVHpSRFRHdHFOVEYzYldvMGFXVnpXWFlLTlU0MlJGbG9aMmhRYW5GUlJuZEhXVWs1WjBaakwxZFlObEZOU1Zkb05WbElWVEpPUjNoeWJVMDNTMlppUVZsNmVqWlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZyVVRJdkNrODBSbWwyYWpGaVZIRTNUbFJSWTNwdE1WSmtkRmxCZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBsbldVUldVakJTUVZGSUwwSkNaM2RHYjBWVlkwZEdhV0pIT1c1ak1rWnpVVWhDTldSSGFIWmlhVFYyWTIxamQwdFJXVXRMZDFsQ1FrRkhSQXAyZWtGQ1FWRlJZbUZJVWpCalNFMDJUSGs1YUZreVRuWmtWelV3WTNrMWJtSXlPVzVpUjFWMVdUSTVkRTFEYzBkRGFYTkhRVkZSUW1jM09IZEJVV2RGQ2toUmQySmhTRkl3WTBoTk5reDVPV2haTWs1MlpGYzFNR041Tlc1aU1qbHVZa2RWZFZreU9YUk5TVWRNUW1kdmNrSm5SVVZCWkZvMVFXZFJRMEpJTUVVS1pYZENOVUZJWTBFelZEQjNZWE5pU0VWVVNtcEhValJqYlZkak0wRnhTa3RZY21wbFVFc3pMMmcwY0hsblF6aHdOMjgwUVVGQlIxaE9NRTUzUjNkQlFRcENRVTFCVTBSQ1IwRnBSVUUyY0VRNFVHcFRLelY2TWxOUmNtVXZUbE12ZDA5a1JsTnFWazF6ZUhaMFprWTJRVEZxWnlzeFZETlpRMGxSUkVNME5GTXZDbG96WXpCa1RtUmtUVGRGYTBVclFUTnFOMVptZEROb2NWSlZiMFpyVG1VMFZUWm5OWEZVUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFRVFlLYkVKSk1uSXpTME5hUm1Nck1tRm1abkJJTTFNeldHb3paMDFQUzJnNFRISTFXamRVWjJ0SGNETlJObEZ6YmtWNFIyMUtTakJzWlZob2NVZzJjbEZyUXdwTlVVUm1lR3N2TmtSNWFHSlBOMHRVY2tsVlptMXlZbHB2WVRka1ZqYzFZM0psYzBwVE5qbFlhelkzV0U0MU4zRnpjVmsxTWtSYWFqbHZOR1ppVlVsM0NqUnliejBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "j7X5+8dgn6giyzFUmIRXXbf9llfL/7iVELXXl1ljqDo="
+                },
+                "signature": "MEUCIQC9CRYF3RXe3t3qBPIwe+GzL12B9uKN2+DZVkbcemEM/wIgO01JiXgmBqdCyEXh3NIPKyBTAohir6GNHYuxbILJ49Q="
+            }
+        }
+    }
+]

--- a/versions/3.12.11.json
+++ b/versions/3.12.11.json
@@ -1,0 +1,142 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tgz",
+        "sha256": "7b8d59af8216044d2313de8120bfc2cc00a9bd2e542f15795e1d616c51faf3d6",
+        "release_url": "https://www.python.org/downloads/release/python-31211/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "45bda920329568dd6650b0ac556d17db",
+            "File Size": "25.9\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tgz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tgz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tgz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyTCCAk+gAwIBAgIULLWQubsNO6Y8jXSGCWXJeu+Wr80wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTczMzMxWhcNMjUwNjAzMTc0MzMxWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXobCE3pQfsLDrO4XTtm/cSPNEqxW7XAkBnj55XGxHObFASgHrlBlmGIH5lP7PegABVHEnyB8oS+qJsT0g76+uqOCAW4wggFqMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUuWTzHKCLxN6ibA+GYDtjK9YKIo8wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXNtsB7AAABAMARjBEAiAWiwTCeG1XEfvrBcptUeN99VEzuZRBavkxLK2Kb+fCdAIgSHIksIdTLg0NuOejIazIKwfqOxK886gb5L7gi2pQFUQwCgYIKoZIzj0EAwMDaAAwZQIwb/ztTk556zLNKMehWSr2S07k5JJ5LrOsjUmg1DuSeJf3/IZx7TGfaM2c6bBAoBKDAjEAmFY4uw0wVSdQ8TxdHgaWn/bbfa65bgdnmXQwrmEWdjheDV0IVGNgUzrWYRtbvAzs"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228873962",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748972012",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIHduAF0nPcTgCkNEywdauEqtH608AZjDLqF9JDX3p4QwAiEAwILiH+/0EvkK24utJfjPW21GtXVWkhCVabKBnG215D8="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "106969700",
+                            "rootHash": "KbqHbDlIqhBVbYu3msuWuTsPAakIz2kQbWTmlo/7Xzg=",
+                            "treeSize": "106969701",
+                            "hashes": [
+                                "G81DEF9R/D3Qs9xIjMal6S+M/CJ9XCZ8MQnl9MnoLU8=",
+                                "ZKbsPoxJNrfjixgg94EwxVWs6762n055DWj0F8a6WLY=",
+                                "fzmeqtuDV3UH6Fw3QnnweVj8MHi40eTI3xUN8Rdv/9g=",
+                                "n5MzQvR+waONXmENXriYi92eiz9pa5whuAyHmzyZa9Q=",
+                                "S+DrHAWb67kO9sHsAjIJ89A0RLlbeXy6mUvzoKO3dMI=",
+                                "JQ9xTJKo/o9IWVV8l4RTm06tpXUcGCeAh8ciAprOIoE=",
+                                "pqCD1LoiP58WZ9AfwL1uMRLqmiQQKDHHSdnl+4lB+/0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n106969701\nKbqHbDlIqhBVbYu3msuWuTsPAakIz2kQbWTmlo/7Xzg=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiA8T1SgovSuAcrgg/P/9j+liw8bBQQZ9+l/lRiy4hrAGAIhAPaR2v4bjw/b9iStKkBHN27SEHk6jFB78Mj7R+BXEhdQ\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3YjhkNTlhZjgyMTYwNDRkMjMxM2RlODEyMGJmYzJjYzAwYTliZDJlNTQyZjE1Nzk1ZTFkNjE2YzUxZmFmM2Q2In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJRmtWV2U5dFlaWms2T3laclkyL3l3UWU5R2w0SjhORTgrY1cxZ2pZUENBY0FpRUFwWVZEejlvaWNET0ZIMWFoaVVBdkZjWWRsMERrdWkxdVl2bHFneWtxcUQwPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVWRU5EUVdzclowRjNTVUpCWjBsVlRFeFhVWFZpYzA1UE5sazRhbGhUUjBOWFdFcGxkU3RYY2pnd2QwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHTjZUWHBOZUZkb1kwNU5hbFYzVG1wQmVrMVVZekJOZWsxNFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZZYjJKRFJUTndVV1p6VEVSeVR6UllWSFJ0TDJOVFVFNUZjWGhYTjFoQmEwSnVhalVLTlZoSGVFaFBZa1pCVTJkSWNteENiRzFIU1VnMWJGQTNVR1ZuUVVKV1NFVnVlVUk0YjFNcmNVcHpWREJuTnpZcmRYRlBRMEZYTkhkblowWnhUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlYxVjFSNkNraExRMHg0VGpacFlrRXJSMWxFZEdwTE9WbExTVzg0ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwcENaMjl5UW1kRlJVRmtXalZCWjFGRFFraHpSV1ZSUWpNS1FVaFZRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U1MGMwSTNRVUZCUWtGTlFRcFNha0pGUVdsQlYybDNWRU5sUnpGWVJXWjJja0pqY0hSVlpVNDVPVlpGZW5WYVVrSmhkbXQ0VEVzeVMySXJaa05rUVVsblUwaEphM05KWkZSTVp6Qk9DblZQWldwSllYcEpTM2RtY1U5NFN6ZzRObWRpTlV3M1oya3ljRkZHVlZGM1EyZFpTVXR2V2tsNmFqQkZRWGROUkdGQlFYZGFVVWwzWWk5NmRGUnJOVFVLTm5wTVRrdE5aV2hYVTNJeVV6QTNhelZLU2pWTWNrOXphbFZ0WnpGRWRWTmxTbVl6TDBsYWVEZFVSMlpoVFRKak5tSkNRVzlDUzBSQmFrVkJiVVpaTkFwMWR6QjNWbE5rVVRoVWVHUklaMkZYYmk5aVltWmhOalZpWjJSdWJWaFJkM0p0UlZka2FtaGxSRll3U1ZaSFRtZFZlbkpYV1ZKMFluWkJlbk1LTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "e41Zr4IWBE0jE96BIL/CzACpvS5ULxV5Xh1hbFH689Y="
+                },
+                "signature": "MEUCIFkVWe9tYZZk6OyZrY2/ywQe9Gl4J8NE8+cW1gjYPCAcAiEApYVDz9oicDOFH1ahiUAvFcYdl0Dkui1uYvlqgykqqD0="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz",
+        "sha256": "c30bb24b7f1e9a19b11b55a546434f74e739bb4c271a3e3a80ff4380d49f7adb",
+        "release_url": "https://www.python.org/downloads/release/python-31211/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "9613d56b90d0d0cfd19980c7e2956a06",
+            "File Size": "19.6\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlGgAwIBAgIUYnM19yJLe8BOsB5QSK0ApWs7UFYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTczMzU5WhcNMjUwNjAzMTc0MzU5WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEorc8E1btqvKxfzhMFNReGMAAH20rdFPI7kk7GPHd6PdKM7voZXQ95LgSzo2plgysqaIgn3em1cFPQ4JDfZj8FqOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUVdDqigJFvvkJ9bwHazqUCUbFWHwwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXNttt1QAABAMASDBGAiEAqqQMp3XA3a5TFLhTtiligp2CQqGlqGE/KfJbdVIQnjUCIQDVOfo4//KX7sZMwYpkhdj7xr/H60oTncyTAQjov+3OTTAKBggqhkjOPQQDAwNoADBlAjEA7RpgIF7whv9DvpnOVavPj4kQxM+gIbCvib3ue2STONKO+JnllxtScT+CypbscLT4AjBQFn7rmkKLgY/lT8YTDf9DqvopFJHXCdlbitQ1imoqOhZqJMEI17CMKMdBcc+BmnU="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228874048",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748972040",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQDC8I5uDgetSuD63qAPtlnnW58xKiSIGEX9AOJ5AnzNEgIgGfb+03Lf8DsOb1NkU5UNmPUeURv4bkQTgiZjtSfGJX0="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "106969786",
+                            "rootHash": "i3vbVg/L11/yzRE1My+dx8hKb/mLlOrFShOkXpDwz/o=",
+                            "treeSize": "106969787",
+                            "hashes": [
+                                "1fUlZVjuybf+gadL7+hmmzV88MK0fLFhuT2TIf4ruWE=",
+                                "h2PCG2d55a7VHzNH7amIjA/LgNJZQAVba+vKss3pYCc=",
+                                "fx5Vsw4rXULuFJQV5sKe1/WI5XEQGzkWHHyU/B1zfYw=",
+                                "iqK8b0KpsJULg7aqHgSStaU4dNbgrth5QDarXmEl3To=",
+                                "5S2DqBJZbuLio6e9iBmJWALzYi0hcpXFV3Z8ydE2lrA=",
+                                "n5MzQvR+waONXmENXriYi92eiz9pa5whuAyHmzyZa9Q=",
+                                "S+DrHAWb67kO9sHsAjIJ89A0RLlbeXy6mUvzoKO3dMI=",
+                                "JQ9xTJKo/o9IWVV8l4RTm06tpXUcGCeAh8ciAprOIoE=",
+                                "pqCD1LoiP58WZ9AfwL1uMRLqmiQQKDHHSdnl+4lB+/0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n106969787\ni3vbVg/L11/yzRE1My+dx8hKb/mLlOrFShOkXpDwz/o=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiBibpE+dFaiZHUWTGPDNXeNfevho16eXV6wm1qMxN/m3wIhAN3M8Rs699nSFmZYP9sEHy6sNglaGwzKb+Nv8tJU7G7B\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJjMzBiYjI0YjdmMWU5YTE5YjExYjU1YTU0NjQzNGY3NGU3MzliYjRjMjcxYTNlM2E4MGZmNDM4MGQ0OWY3YWRiIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQ2piY2JONkNNK1FNbFE4dG1MdkhHbXFuakNrMm9tMmp0WlBsaUdJUWJieUFpQi9wNjAxVTN6RUcxSjFVTk1GWHlCekNhcVhVemhnRTVzVXUwUGFhT2IyelE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4SFowRjNTVUpCWjBsVldXNU5NVGw1U2t4bE9FSlBjMEkxVVZOTE1FRndWM00zVlVaWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHTjZUWHBWTlZkb1kwNU5hbFYzVG1wQmVrMVVZekJOZWxVMVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ2Y21NNFJURmlkSEYyUzNobWVtaE5SazVTWlVkTlFVRklNakJ5WkVaUVNUZHJhemNLUjFCSVpEWlFaRXROTjNadldsaFJPVFZNWjFONmJ6SndiR2Q1YzNGaFNXZHVNMlZ0TVdOR1VGRTBTa1JtV21vNFJuRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZXWkVSeENtbG5Ta1oyZG10S09XSjNTR0Y2Y1ZWRFZXSkdWMGgzZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U1MGRIUXhVVUZCUWtGTlFRcFRSRUpIUVdsRlFYRnhVVTF3TTFoQk0yRTFWRVpNYUZSMGFXeHBaM0F5UTFGeFIyeHhSMFV2UzJaS1ltUldTVkZ1YWxWRFNWRkVWazltYnpRdkwwdFlDamR6V2sxM1dYQnJhR1JxTjNoeUwwZzJNRzlVYm1ONVZFRlJhbTkyS3pOUFZGUkJTMEpuWjNGb2EycFBVRkZSUkVGM1RtOUJSRUpzUVdwRlFUZFNjR2NLU1VZM2QyaDJPVVIyY0c1UFZtRjJVR28wYTFGNFRTdG5TV0pEZG1saU0zVmxNbE5VVDA1TFR5dEtibXhzZUhSVFkxUXJRM2x3WW5OalRGUTBRV3BDVVFwR2JqZHliV3RMVEdkWkwyeFVPRmxVUkdZNVJIRjJiM0JHU2toWVEyUnNZbWwwVVRGcGJXOXhUMmhhY1VwTlJVa3hOME5OUzAxa1FtTmpLMEp0YmxVOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "wwuyS38emhmxG1WlRkNPdOc5u0wnGj46gP9DgNSfets="
+                },
+                "signature": "MEQCICjbcbN6CM+QMlQ8tmLvHGmqnjCk2om2jtZPliGIQbbyAiB/p601U3zEG1J1UNMFXyBzCaqXUzhgE5sUu0PaaOb2zQ=="
+            }
+        }
+    }
+]

--- a/versions/3.13.4.json
+++ b/versions/3.13.4.json
@@ -1,0 +1,637 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tgz",
+        "sha256": "2666038f1521b7a8ec34bf2997b363778118d6f3979282c93723e872bcd464e0",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "264bd0fa99f69d05f582d7909cac2d3f",
+            "File Size": "28.0\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tgz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tgz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tgz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyTCCAlCgAwIBAgIUDhOURTUgVsquhXpiEwnv7WPFMtEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTczMzQ0WhcNMjUwNjAzMTc0MzQ0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZIbjJq+boy3hISD2nBKhzaZ3fDp87tJlz61NJAFBl2jVSFR8aBV0oiYmhkBQuDYuJInnuopcFGBeYkJ3hyWUK6OCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU5QNpwn2DR1Ig26TJ6mrMBY5J52EwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXNtsypwAABAMARzBFAiEAoPzIswa7AVkAuvYcX/Kr9NpcKv9Br0+RGZFfhOAUPWYCIFMNf/Oe0vbmqs28CuqVP0nSQr7Ytv7IFa07VJnRmR08MAoGCCqGSM49BAMDA2cAMGQCMBh+S1Exb6bCxlDkHVz3fq2jdGJdSkUUxumF5KucITrcj9fW6L/C+6LtkV8aZYDOtAIwYzfvfFNEv4PQEg29mjMhEQlOpac8LRdNXmLg+hQWLi1Q5N2mt3HCb2fUXTVKXGvN"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228874012",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748972024",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIAIn2xmvzGb28KpFU8tbQESUwZDnu5kYrQR1hDQMUhEpAiEA6LHxLLd4rUPPSClYRzjcDC1AiyQp7N0TnDCG9SBLcqI="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "106969750",
+                            "rootHash": "a4g6tbnYwPyvWY4JyvQ7yhnOy4JZm3M/mKFBVV37ZF8=",
+                            "treeSize": "106969751",
+                            "hashes": [
+                                "wGwuBIf3R8ZJQ+8oUPzz7i1g51UlXZcimHjjg+ABBLQ=",
+                                "FSf+ztPutiONOGZC+n2dI2yyfCZjSF46s/+cPkXs5zY=",
+                                "LzCS7xTZEhP45g4V1BEY/3UDHRLfSw+A5JjgQULWRzA=",
+                                "5S2DqBJZbuLio6e9iBmJWALzYi0hcpXFV3Z8ydE2lrA=",
+                                "n5MzQvR+waONXmENXriYi92eiz9pa5whuAyHmzyZa9Q=",
+                                "S+DrHAWb67kO9sHsAjIJ89A0RLlbeXy6mUvzoKO3dMI=",
+                                "JQ9xTJKo/o9IWVV8l4RTm06tpXUcGCeAh8ciAprOIoE=",
+                                "pqCD1LoiP58WZ9AfwL1uMRLqmiQQKDHHSdnl+4lB+/0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n106969751\na4g6tbnYwPyvWY4JyvQ7yhnOy4JZm3M/mKFBVV37ZF8=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEAmw10yFgvEYInanzUGVFFX5BfYjmA5b2c9ZtJns+BMpUCIBMGxE+jIqRtiwqwC7sHU1U41TQWjhDgdkVu4mkmNsCV\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIyNjY2MDM4ZjE1MjFiN2E4ZWMzNGJmMjk5N2IzNjM3NzgxMThkNmYzOTc5MjgyYzkzNzIzZTg3MmJjZDQ2NGUwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJRVFSZDY0Z1Z1Q1ZxZGM5MjdySDdhWWx3T21JcVllK1M4QjJLTUtOUmFSekFpRUF0SE5BVUtGektiWkVsUEJuUm9LZnZydmtaM3JpSGVqTm15VEtIb2RIZWtJPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVWRU5EUVd4RFowRjNTVUpCWjBsVlJHaFBWVkpVVldkV2MzRjFhRmh3YVVWM2JuWTNWMUJHVFhSRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHTjZUWHBSTUZkb1kwNU5hbFYzVG1wQmVrMVVZekJOZWxFd1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZhU1dKcVNuRXJZbTk1TTJoSlUwUXlia0pMYUhwaFdqTm1SSEE0TjNSS2JIbzJNVTRLU2tGR1Ftd3lhbFpUUmxJNFlVSldNRzlwV1cxb2EwSlJkVVJaZFVwSmJtNTFiM0JqUmtkQ1pWbHJTak5vZVZkVlN6WlBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlUxVVU1d0NuZHVNa1JTTVVsbk1qWlVTalp0Y2sxQ1dUVktOVEpGZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U1MGMzbHdkMEZCUWtGTlFRcFNla0pHUVdsRlFXOVFla2x6ZDJFM1FWWnJRWFYyV1dOWUwwdHlPVTV3WTB0Mk9VSnlNQ3RTUjFwR1ptaFBRVlZRVjFsRFNVWk5UbVl2VDJVd2RtSnRDbkZ6TWpoRGRYRldVREJ1VTFGeU4xbDBkamRKUm1Fd04xWktibEp0VWpBNFRVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeVkwRk5SMUZEVFVKb0sxTXhSWGdLWWpaaVEzaHNSR3RJVm5velpuRXlhbVJIU21SVGExVlZlSFZ0UmpWTGRXTkpWSEpqYWpsbVZ6Wk1MME1yTmt4MGExWTRZVnBaUkU5MFFVbDNXWHBtZGdwbVJrNUZkalJRVVVWbk1qbHRhazFvUlZGc1QzQmhZemhNVW1ST1dHMU1aeXRvVVZkTWFURlJOVTR5YlhRelNFTmlNbVpWV0ZSV1MxaEhkazRLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "JmYDjxUht6jsNL8pl7Njd4EY1vOXkoLJNyPocrzUZOA="
+                },
+                "signature": "MEUCIEQRd64gVuCVqdc927rH7aYlwOmIqYe+S8B2KMKNRaRzAiEAtHNAUKFzKbZElPBnRoKfvrvkZ3riHejNmyTKHodHekI="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tar.xz",
+        "sha256": "27b15a797562a2971dce3ffe31bb216042ce0b995b39d768cf15f784cc757365",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "2e2a8eb2e1be50049dc4248d99a52f89",
+            "File Size": "21.6\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tar.xz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tar.xz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/Python-3.13.4.tar.xz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlGgAwIBAgIUO5JdWUQQH0AKKhZQ86mzrah+aHgwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTczNDEwWhcNMjUwNjAzMTc0NDEwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgJAyXDyFDJsY+or0M9p1w5KvL3+oZuieOqdDU6Gh9qvOZrWVSvZPOZBGyz/EeUNOJObcOk1IhevZUFhXh5u9NaOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUjB59Lh3csAPMT3DhyuwWeIWhVh0wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXNtuZFwAABAMASDBGAiEAtNGTM9VDDbVXwR3TgugfGns9nzo6R/JOIkUfJuZ5FaACIQDrA24Mj6a4LegeVBvZ9HFL5FwtoJgaea+ENOuA9dD56zAKBggqhkjOPQQDAwNpADBmAjEAlLDQV+HOGajtbJxtOTRltXbNwUwchium//yOldpEu0FM/H/DbeDD9Un81BRL/rn/AjEAhKsjsB/fwcxcSkF1dXI3gbKJEZIrBVoVv6HKV11BY7qOP84vHOquEOz//N3MZIFC"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228874080",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748972051",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQDL78XHlNQD+0lTPncrwH+XfGjXGDl3XgDzU2QjFRoqcQIgRkVgEwkUa1tVdGjQWMMUZfY2Dbkzk1JrrcENoIsng/s="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "106969818",
+                            "rootHash": "+h7KA5AELljEYPaFPgSmnZyY0Da3w9hxsf5RPjjvol0=",
+                            "treeSize": "106969820",
+                            "hashes": [
+                                "+wFAYkn4BCFt0K3mtMHu6s8tG6bbKjXsXaHhz1z1xEM=",
+                                "8pBLgkVh8zd9pK662U3mjwsxnwg4ZApT/iml+5U4n0E=",
+                                "yP7p3olgvk5E8bbyCn5V/xJhQY0z23Y8T3JoBBQzBBc=",
+                                "zP7tQ4DpmQptR54rK1PpfdlvfPZBalQEYcdFCrn2W8c=",
+                                "Q1gnGCWZvzY0Px0RpNv8hIRPQLEcyGLYhugDpYkxoE4=",
+                                "5S2DqBJZbuLio6e9iBmJWALzYi0hcpXFV3Z8ydE2lrA=",
+                                "n5MzQvR+waONXmENXriYi92eiz9pa5whuAyHmzyZa9Q=",
+                                "S+DrHAWb67kO9sHsAjIJ89A0RLlbeXy6mUvzoKO3dMI=",
+                                "JQ9xTJKo/o9IWVV8l4RTm06tpXUcGCeAh8ciAprOIoE=",
+                                "pqCD1LoiP58WZ9AfwL1uMRLqmiQQKDHHSdnl+4lB+/0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n106969820\n+h7KA5AELljEYPaFPgSmnZyY0Da3w9hxsf5RPjjvol0=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAs6seTO9AxVZIS/HmvX1ZRibir/qonYfB+9RAgl/DZB4CIQCq+rKh4xxwYTzpbdg4zDl77noWEK27NCTE0TinoQM+5Q==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIyN2IxNWE3OTc1NjJhMjk3MWRjZTNmZmUzMWJiMjE2MDQyY2UwYjk5NWIzOWQ3NjhjZjE1Zjc4NGNjNzU3MzY1In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJRU5GcjFleURKbk0xeEdnOWNjaFZPL3poUUhIT0d1VCttTjhVbzZOQWJWVEFpQXBrdFhIRFR4eXZNbUJTWjN6dUFuR0NLNkV0Q0dFdyt1bENUZDk3anVvU3c9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4SFowRjNTVUpCWjBsVlR6VktaRmRWVVZGSU1FRkxTMmhhVVRnMmJYcHlZV2dyWVVobmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHTjZUa1JGZDFkb1kwNU5hbFYzVG1wQmVrMVVZekJPUkVWM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZuU2tGNVdFUjVSa1JLYzFrcmIzSXdUVGx3TVhjMVMzWk1NeXR2V25WcFpVOXhaRVFLVlRaSGFEbHhkazlhY2xkV1UzWmFVRTlhUWtkNWVpOUZaVlZPVDBwUFltTlBhekZKYUdWMldsVkdhRmhvTlhVNVRtRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZxUWpVNUNreG9NMk56UVZCTlZETkVhSGwxZDFkbFNWZG9WbWd3ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U1MGRWcEdkMEZCUWtGTlFRcFRSRUpIUVdsRlFYUk9SMVJOT1ZaRVJHSldXSGRTTTFSbmRXZG1SMjV6T1c1NmJ6WlNMMHBQU1d0VlprcDFXalZHWVVGRFNWRkVja0V5TkUxcU5tRTBDa3hsWjJWV1FuWmFPVWhHVERWR2QzUnZTbWRoWldFclJVNVBkVUU1WkVRMU5ucEJTMEpuWjNGb2EycFBVRkZSUkVGM1RuQkJSRUp0UVdwRlFXeE1SRkVLVml0SVQwZGhhblJpU25oMFQxUlNiSFJZWWs1M1ZYZGphR2wxYlM4dmVVOXNaSEJGZFRCR1RTOUlMMFJpWlVSRU9WVnVPREZDVWt3dmNtNHZRV3BGUVFwb1MzTnFjMEl2Wm5kamVHTlRhMFl4WkZoSk0yZGlTMHBGV2tseVFsWnZWblkyU0V0V01URkNXVGR4VDFBNE5IWklUM0YxUlU5Nkx5OU9NMDFhU1VaRENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "J7FaeXViopcdzj/+MbshYELOC5lbOddozxX3hMx1c2U="
+                },
+                "signature": "MEQCIENFr1eyDJnM1xGg9cchVO/zhQHHOGuT+mN8Uo6NAbVTAiApktXHDTxyvMmBSZ3zuAnGCK6EtCGEw+ulCTd97juoSw=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-macos11.pkg",
+        "sha256": "f6812415a25c440ed48efcb3b698812425425cf9187d3ccbee19a8fe23af3be0",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-macos11.pkg",
+            "Operating System": "macOS",
+            "Description": "for macOS 10.13 and later",
+            "MD5 Sum": "9aa9fa33aeb16f47703b05f0053fbc09",
+            "File Size": "67.0\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-macos11.pkg.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-macos11.pkg.sigstore",
+            "SBOM": null
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyTCCAk+gAwIBAgIUaQsbUZOjS1pWR18k7bAeTDX8ItYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDE4WhcNMjUwNjAzMjAzNDE4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECTNuUHpMj08yMETRFmO1htClsj39fGdHbzXgTzTnPH25h717ngVGgHg61+oLvUHoU6XczveqOr0jh98tGq8Zy6OCAW4wggFqMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUdZcczpSbGDnO9hRZ/u8Ma5KWrHowHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3da6wAABAMARjBEAiA4Woxz3uBSW2yevAzaK91DsKFePGZVFe9tbuDOvlxM0wIgSARjUJJjjSfE6JwUyn2LXUl2ROckWnEHzSWlabxxa0EwCgYIKoZIzj0EAwMDaAAwZQIxAKjHVJ5NuQpkkUdpiHoOKUDnWfVZZQEezD7S+sx7aox0ZZ2pmcFxEl9r85XyOWUZyAIwTtUJwnoRJ6BPm1Aj6mdPyUJn+KFb/CpHa47rAayRg08BpdTidNG1YDUAuyZt5oYt"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995353",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982259",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEQCIC5ARdZmDwJkNAL0xeBU5CMxGW2IHDc+NqYmpPGy7x0uAiBFc7Ir/36iX7Q6Jk5HDjEhgtajnuiNBlhORyd1BMsc2g=="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107091091",
+                            "rootHash": "N/ELx2PICInpxj6ukmOmW89zwQPB4LkBbMTlRoFq564=",
+                            "treeSize": "107091096",
+                            "hashes": [
+                                "vGdbCf+U7SFNIuoAKOCE9boQw0C2Sob31Qkb52sb2iM=",
+                                "vKq0A3kvwajg4hEnZw6QRRBxfv01yTll8sWcR02rw1I=",
+                                "XsXJmzjXfc9jjwuQadsqd09JqeR53t19i7HtOEqluFA=",
+                                "ugk0LkaO5hQ+Ilo30XJP2viI0xKt9BHsfM3R10hsPec=",
+                                "4GorxjyYZabNYM9pgwQvO/zCa0v0DTBi8PTiyUqk2xc=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107091096\nN/ELx2PICInpxj6ukmOmW89zwQPB4LkBbMTlRoFq564=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEAndAo9Kswki26S2UvY6kXOSRJnQaV1C3U7aNrHAKJerYCIDJ1/390GcafutN/nrKx5mVZPj6nSy3Tl9LxWfzfWyqG\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJmNjgxMjQxNWEyNWM0NDBlZDQ4ZWZjYjNiNjk4ODEyNDI1NDI1Y2Y5MTg3ZDNjY2JlZTE5YThmZTIzYWYzYmUwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUR4d3cvMS9JTzlKY2pyV1l6bS9DcE9lQWVZcEZ2bG4yN1Z6bitsSUJIdVV3SWdlNmY0UlRyNzVYdnRCMkQ0QWFIV1BVQzVvSjc5YW45M3IvM1JjQllyekVNPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVWRU5EUVdzclowRjNTVUpCWjBsVllWRnpZbFZhVDJwVE1YQlhVakU0YXpkaVFXVlVSRmc0U1hSWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JGTkZkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVVMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZEVkU1MVZVaHdUV293T0hsTlJWUlNSbTFQTVdoMFEyeHphak01Wmtka1NHSjZXR2NLVkhwVWJsQklNalZvTnpFM2JtZFdSMmRJWnpZeEsyOU1kbFZJYjFVMldHTjZkbVZ4VDNJd2FtZzVPSFJIY1RoYWVUWlBRMEZYTkhkblowWnhUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZrV21OakNucHdVMkpIUkc1UE9XaFNXaTkxT0UxaE5VdFhja2h2ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwcENaMjl5UW1kRlJVRmtXalZCWjFGRFFraHpSV1ZSUWpNS1FVaFZRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpHRTJkMEZCUWtGTlFRcFNha0pGUVdsQk5GZHZlSG96ZFVKVFZ6SjVaWFpCZW1GTE9URkVjMHRHWlZCSFdsWkdaVGwwWW5WRVQzWnNlRTB3ZDBsblUwRlNhbFZLU21wcVUyWkZDalpLZDFWNWJqSk1XRlZzTWxKUFkydFhia1ZJZWxOWGJHRmllSGhoTUVWM1EyZFpTVXR2V2tsNmFqQkZRWGROUkdGQlFYZGFVVWw0UVV0cVNGWktOVTRLZFZGd2EydFZaSEJwU0c5UFMxVkVibGRtVmxwYVVVVmxla1EzVXl0emVEZGhiM2d3V2xveWNHMWpSbmhGYkRseU9EVlllVTlYVlZwNVFVbDNWSFJWU2dwM2JtOVNTalpDVUcweFFXbzJiV1JRZVZWS2JpdExSbUl2UTNCSVlUUTNja0ZoZVZKbk1EaENjR1JVYVdST1J6RlpSRlZCZFhsYWREVnZXWFFLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "9oEkFaJcRA7UjvyztpiBJCVCXPkYfTzL7hmo/iOvO+A="
+                },
+                "signature": "MEUCIQDxww/1/IO9JcjrWYzm/CpOeAeYpFvln27Vzn+lIBHuUwIge6f4RTr75XvtB2D4AaHWPUC5oJ79an93r/3RcBYrzEM="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe",
+        "sha256": "94f53bb832539ea02d6ce581d7c1fcc36228e04a611b8dcfe797ad4bbc0a45c1",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe",
+            "Operating System": "Windows",
+            "Description": "Recommended",
+            "MD5 Sum": "ee91d61ba59659d23eba4347995163bc",
+            "File Size": "27.3\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlGgAwIBAgIUErrDVMg1mog5+zvN2ViCdNNL2eEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDIwWhcNMjUwNjAzMjAzNDIwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Iw0HZWUgFSD1DX+Hv8XSJ8dLHThbfRJlzWPLRtLaPSYS7UvXL59ovM+R5aprd+Bg6ZsvT4+lgr6J2LjYmZXXqOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUQOFIKmeCkXTjCBjxxoUOk1oxqkgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3di8gAABAMASDBGAiEA9VnV7msBQruzqZriNZTblO86T8XNtAem6tFQv4XdqYkCIQCEAQQ1bTL9H0aML8Ijnko6aD1IG00+BtjmMc0U81kGNDAKBggqhkjOPQQDAwNoADBlAjBMf3ZBBLY6JuUo977qSqFTu6eu2homQpDEfVe1o7Eseq46OPL7Z8tZB77ucVgblScCMQCzyoNKG3ks5W7aZ3lovszzGoV+OEgwOgcwSUQKrem0Sc2hizpUwneLhfYLSAEQRpw="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995453",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982260",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCID/wJE1s530oR2Guvfn+b07ZJ4X27ybE0jX/kV9iyNsWAiEA1w60+dZnZUSSYT6Pqn0Y3G6PNlyyHcoEXp/PM2xZQQw="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107091191",
+                            "rootHash": "eUceSl7X30dYpA8IaV1VLFupkcxpiK35kgYNnNIvdis=",
+                            "treeSize": "107091199",
+                            "hashes": [
+                                "KMMkKO/8kk7HiPdJXGkbxx33HPx8sPZs1lhXvDiL0+0=",
+                                "tPnC5grLlca/XNk/HxCka9yk8mmZelaAsE3yUkjtFbQ=",
+                                "IShg0h8LpgwyePbmdUp953rBTiaE4pC38P3B+ntZsjo=",
+                                "xjOccKOi2sVtzZKPGJG7p0/fRg0gp+vcaL9m70kDy98=",
+                                "QbSwyf2tI1AAIDKx9CJPyKjfQZVNcYPVAAlKHrO3vNs=",
+                                "oYCgZj5E1Alg/mA/o7UA7YhZKrGwKVunUFulezsuL8c=",
+                                "Y6Rz9JY4wvMFjUTGIIKFIeLx7cGFgGCrYv2x66Q8aA0=",
+                                "4GorxjyYZabNYM9pgwQvO/zCa0v0DTBi8PTiyUqk2xc=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107091199\neUceSl7X30dYpA8IaV1VLFupkcxpiK35kgYNnNIvdis=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEA/0VJV6JvjLaHtTQ7wj9w+UZAwvxszsN+1gHZFabPEM4CIQCawAoxIaUE8EQdxWK6v+vwblVEVB34GpYkhxXxKeCokA==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI5NGY1M2JiODMyNTM5ZWEwMmQ2Y2U1ODFkN2MxZmNjMzYyMjhlMDRhNjExYjhkY2ZlNzk3YWQ0YmJjMGE0NWMxIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUUNkbDVQQy9CK01Xb0E1RUgwRlJaVTlEdmZabDYvUXoybmJVdjN1Q2NybXNnSWhBSWRmbmk1VHRHaXRjR2dOcUNacVduOENyRk5WWGd2ZzhVaXloT2FCNHdDVyIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4SFowRjNTVUpCWjBsVlJYSnlSRlpOWnpGdGIyYzFLM3AyVGpKV2FVTmtUazVNTW1WRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JKZDFkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVsM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVV2U1hjd1NGcFhWV2RHVTBReFJGZ3JTSFk0V0ZOS09HUk1TRlJvWW1aU1NteDZWMUFLVEZKMFRHRlFVMWxUTjFWMldFdzFPVzkyVFN0U05XRndjbVFyUW1jMlduTjJWRFFyYkdkeU5rb3lUR3BaYlZwWVdIRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZSVDBaSkNrdHRaVU5yV0ZScVEwSnFlSGh2VlU5ck1XOTRjV3RuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpHazRaMEZCUWtGTlFRcFRSRUpIUVdsRlFUbFdibFkzYlhOQ1VYSjFlbkZhY21sT1dsUmliRTg0TmxRNFdFNTBRV1Z0Tm5SR1VYWTBXR1J4V1d0RFNWRkRSVUZSVVRGaVZFdzVDa2d3WVUxTU9FbHFibXR2Tm1GRU1VbEhNREFyUW5ScWJVMWpNRlU0TVd0SFRrUkJTMEpuWjNGb2EycFBVRkZSUkVGM1RtOUJSRUpzUVdwQ1RXWXpXa0lLUWt4Wk5rcDFWVzg1TnpkeFUzRkdWSFUyWlhVeWFHOXRVWEJFUldaV1pURnZOMFZ6WlhFME5rOVFURGRhT0hSYVFqYzNkV05XWjJKc1UyTkRUVkZEZWdwNWIwNUxSek5yY3pWWE4yRmFNMnh2ZG5ONmVrZHZWaXRQUldkM1QyZGpkMU5WVVV0eVpXMHdVMk15YUdsNmNGVjNibVZNYUdaWlRGTkJSVkZTY0hjOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "lPU7uDJTnqAtbOWB18H8w2Io4EphG43P55etS7wKRcE="
+                },
+                "signature": "MEYCIQCdl5PC/B+MWoA5EH0FRZU9DvfZl6/Qz2nbUv3uCcrmsgIhAIdfni5TtGitcGgNqCZqWn8CrFNVXgvg8UiyhOaB4wCW"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4.exe",
+        "sha256": "b3fece33b3402d563da434e938ce5ce52332bdaeda50696aa31886e8b0486ba6",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4.exe",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "7046126db6362e759988af4ec16faa44",
+            "File Size": "26.1\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4.exe.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/python-3.13.4.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlGgAwIBAgIUXg2iKWroZ7SizgXI2T6nUf/dAdIwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDI0WhcNMjUwNjAzMjAzNDI0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+MdiQ4UXBfNnVKenMRQ9RKaoXBQ8VioIniB5ob/ZnO0gXIBV3kxxDId5wMFqbqW0R3+Um/eI4UkGfrVOm3h3AqOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU9ksTI4ycH1ZA99Qj3L3WbQ27rO8wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3dxEAAABAMASDBGAiEAoV0MA0v5lMhUPPccOgqRPM3gohLReY84QWMbrfrH/EoCIQDpXkZi9KowzIdiWusHObeIm1FnUjDmUx4BzmBOCNgmWDAKBggqhkjOPQQDAwNoADBlAjBwmwTSTn91oayQp4Z1Jovc76G+UI/7NkKZJqPiOR7SrMUG7y8J82mkAzv5pXz8eyICMQDUE8YTbK8T/j256DgOpjGOWNi/gIXMbg8yp1F8B7ZIwHPmnjE3DfSNSlDBWTrkAGw="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995578",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982264",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQCorfXlLAedpdI20U+iscCP+MTWsGuFLf2FAV1no7pZ+wIhAMOxI+WhJjWwa60rG3XJABOUQxW3RgTA4TLIPYPTQSY6"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107091316",
+                            "rootHash": "m/9xwNeZHPOIcbfv4+EnHRWqACERQ2VB6zBz08FIVAU=",
+                            "treeSize": "107091321",
+                            "hashes": [
+                                "CRt46ygZ80q9j4d97ZQCA70Clnm1Uk8H6Onwa9dWbgI=",
+                                "kf3HS4u9bf5jlOPm/DjQsH7BvjJcO+E4WpMcO76Lvio=",
+                                "8ckKHqPeLA6ZWb1p0mV1T2tLvqm0nuD2z0ccwQBN1eA=",
+                                "P6WGZEz8eWYVuRFZcNw8faOFs9T+NQbZ1R4kCCimLqM=",
+                                "vA7JD1YC/Vzhe0OfezES/mhxFjEdLJ/kOArvpyfxkwU=",
+                                "0YZ6eOY9m6kQMo50Xxo+CfFRDsZnGl169O2qq9OBHYc=",
+                                "Suse5bdNSeD6QZIuCWHb/twhWXlzbMwJUm+LGsMFW3U=",
+                                "KU0MbHtorg+1UHHUvGziPf09hiEPp4dg3figLbRZru8=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107091321\nm/9xwNeZHPOIcbfv4+EnHRWqACERQ2VB6zBz08FIVAU=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEA3hMuk10OEfEQjFY6+j5m4UCEUqh1SVGGOGiAEvYk4RcCICkHvWxnAwelWb+5ICdNzCsmfDWBr31f8vdjp0i01B1z\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJiM2ZlY2UzM2IzNDAyZDU2M2RhNDM0ZTkzOGNlNWNlNTIzMzJiZGFlZGE1MDY5NmFhMzE4ODZlOGIwNDg2YmE2In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQU03ZUxQYjRKdjBrMkdXdlNHcXpqUFU5Rzh3UE5ERExsUlBqbXYxWGt2WUFpQTVkdElXT0ZSNVJzR2o2aGdsTVRzRlZEakljR1lwYm82WGxlbjhQK0pBTFE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4SFowRjNTVUpCWjBsVldHY3lhVXRYY205YU4xTnBlbWRZU1RKVU5tNVZaaTlrUVdSSmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JKTUZkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVrd1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVVyVFdScFVUUlZXRUptVG01V1MyVnVUVkpST1ZKTFlXOVlRbEU0Vm1sdlNXNXBRalVLYjJJdldtNVBNR2RZU1VKV00ydDRlRVJKWkRWM1RVWnhZbkZYTUZJeksxVnRMMlZKTkZWclIyWnlWazl0TTJnelFYRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlU1YTNOVUNrazBlV05JTVZwQk9UbFJhak5NTTFkaVVUSTNjazg0ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpIaEZRVUZCUWtGTlFRcFRSRUpIUVdsRlFXOVdNRTFCTUhZMWJFMW9WVkJRWTJOUFozRlNVRTB6WjI5b1RGSmxXVGcwVVZkTlluSm1ja2d2Ulc5RFNWRkVjRmhyV21rNVMyOTNDbnBKWkdsWGRYTklUMkpsU1cweFJtNVZha1J0VlhnMFFucHRRazlEVG1kdFYwUkJTMEpuWjNGb2EycFBVRkZSUkVGM1RtOUJSRUpzUVdwQ2QyMTNWRk1LVkc0NU1XOWhlVkZ3TkZveFNtOTJZemMyUnl0VlNTODNUbXRMV2tweFVHbFBVamRUY2sxVlJ6ZDVPRW80TW0xclFYcDJOWEJZZWpobGVVbERUVkZFVlFwRk9GbFVZa3M0VkM5cU1qVTJSR2RQY0dwSFQxZE9hUzluU1ZoTlltYzRlWEF4UmpoQ04xcEpkMGhRYlc1cVJUTkVabE5PVTJ4RVFsZFVjbXRCUjNjOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "s/7OM7NALVY9pDTpOM5c5SMyva7aUGlqoxiG6LBIa6Y="
+                },
+                "signature": "MEQCIAM7eLPb4Jv0k2GWvSGqzjPU9G8wPNDDLlRPjmv1XkvYAiA5dtIWOFR5RsGj6hglMTsFVDjIcGYpbo6Xlen8P+JALQ=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-arm64.exe",
+        "sha256": "2a91c47d028f5de2746c95967516767321f702706a449454c2b060bbd406c769",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-arm64.exe",
+            "Operating System": "Windows",
+            "Description": "Experimental",
+            "MD5 Sum": "f133357fff1dba8b19288d4bc115c9dd",
+            "File Size": "26.6\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-arm64.exe.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-arm64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-arm64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyTCCAlCgAwIBAgIUXLklLlUYhJspBvFmWxrV2lcGttswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDIyWhcNMjUwNjAzMjAzNDIyWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE88h3kMnjFTyVfDgKhqUTEksrtlk324/bcQihuHCNIFrib7HwV5c/sEJtlESlHGiabyZEp6nXxLr7dCsW0OFpnqOCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUmuspXDozxO7/Sc9HmSPhPtja39AwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3dqFwAABAMARzBFAiEAy+lvWlPxsTFlONDph5fu5ipicwzbwsmr0r7uFzOa1iECICBV/OImxtEE1q1MzRZoHAMY5j19BfjxEg968nfYWEVMMAoGCCqGSM49BAMDA2cAMGQCMGFmK1ZflLUlnPjtVC/44PXWU5AJq3mRGeBwDuiNW8CYIx6MoGOfMxCa3AfNxg1AbgIwQiJYHhOM7rLLXuBVQEEe744Wt55xanc0uL3mkIvOrSnZFK7oxU/D94MVwh+qTPcc"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995523",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982262",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQC7Vp+yV7hOMOsSm1yAxgXh2a3rPDhClo/KXVHnO+gNbwIgSGLE+OoPqa9B2Iv9Q6tsRxBzUkXUb/rSoiZsm7KzDGQ="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107091261",
+                            "rootHash": "QowweV9S9R9fcqNNixtlvn+DicRNbt5+5V3EHHEEfvo=",
+                            "treeSize": "107091266",
+                            "hashes": [
+                                "HaGDpDAI4hJHA7+kTfC8r2NH66bAu0PSnqSgm+zPY3E=",
+                                "LysAqAUXYR0vGzmFX8K5YghMtOVlwCzC+NoVWDYSk4Q=",
+                                "X93pYpE3UK0elA3LYSwiLKxfnqFW4PueHHcFcQAqi6Y=",
+                                "HAvIGaN3ENJtE5h64MNrFxL5nfqdqbpeYeP2hLWObeo=",
+                                "d0ZDJ/ZtJI9aFmNCtSB0dXebrnDYUpThxdzIF2i5pHA=",
+                                "ViBFdm3DPtwpbCPu4Ipj1O5A92EXOMduv308kfsMKKo=",
+                                "5JOTdsr6EpSXUKnOiDxfYBeQOu934FHYKQUcn9GSFFo=",
+                                "KU0MbHtorg+1UHHUvGziPf09hiEPp4dg3figLbRZru8=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107091266\nQowweV9S9R9fcqNNixtlvn+DicRNbt5+5V3EHHEEfvo=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiBsb/JLInuryV/KR+9pWSEMcQwc05IhxB/+avXdmu0BCAIhAL1vpugHdTfGzBjt6OpqPYswXzMXGvWCFB0eIw3wxqLI\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIyYTkxYzQ3ZDAyOGY1ZGUyNzQ2Yzk1OTY3NTE2NzY3MzIxZjcwMjcwNmE0NDk0NTRjMmIwNjBiYmQ0MDZjNzY5In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUURZdUZDR1JZT2o0U2YyVzh0dFkwdmJJeHhkVm91NlJnVUZPajJvYmRCbWpnSWdJcFYzMG9ITno2eHJqeVRRL29nYXc5WHk5TmdrelZSbklrL3hqOVFBTWEwPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVWRU5EUVd4RFowRjNTVUpCWjBsVldFeHJiRXhzVlZsb1NuTndRblpHYlZkNGNsWXliR05IZEhSemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JKZVZkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVsNVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVU0T0dnemEwMXVha1pVZVZabVJHZExhSEZWVkVWcmMzSjBiR3N6TWpRdlltTlJhV2dLZFVoRFRrbEdjbWxpTjBoM1ZqVmpMM05GU25Sc1JWTnNTRWRwWVdKNVdrVndObTVZZUV4eU4yUkRjMWN3VDBad2JuRlBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ0ZFhOd0NsaEViM3A0VHpjdlUyTTVTRzFUVUdoUWRHcGhNemxCZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpIRkdkMEZCUWtGTlFRcFNla0pHUVdsRlFYa3JiSFpYYkZCNGMxUkdiRTlPUkhCb05XWjFOV2x3YVdOM2VtSjNjMjF5TUhJM2RVWjZUMkV4YVVWRFNVTkNWaTlQU1cxNGRFVkZDakZ4TVUxNlVscHZTRUZOV1RWcU1UbENabXA0UldjNU5qaHVabGxYUlZaTlRVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeVkwRk5SMUZEVFVkR2JVc3hXbVlLYkV4VmJHNVFhblJXUXk4ME5GQllWMVUxUVVweE0yMVNSMlZDZDBSMWFVNVhPRU5aU1hnMlRXOUhUMlpOZUVOaE0wRm1UbmhuTVVGaVowbDNVV2xLV1FwSWFFOU5OM0pNVEZoMVFsWlJSVVZsTnpRMFYzUTFOWGhoYm1Nd2RVd3piV3RKZGs5eVUyNWFSa3MzYjNoVkwwUTVORTFXZDJncmNWUlFZMk1LTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "KpHEfQKPXeJ0bJWWdRZ2cyH3AnBqRJRUwrBgu9QGx2k="
+                },
+                "signature": "MEUCIQDYuFCGRYOj4Sf2W8ttY0vbIxxdVou6RgUFOj2obdBmjgIgIpV30oHNz6xrjyTQ/ogaw9Xy9NgkzVRnIk/xj9QAMa0="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-amd64.zip",
+        "sha256": "514ca14ec356ecb7749a7c0a1ef1eac9fd9c67d57af4812cb1f0822b0d3a85e8",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-amd64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "7820da5998bf7d5d25530d871a1e0e28",
+            "File Size": "10.4\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-amd64.zip.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-amd64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-amd64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyjCCAlGgAwIBAgIURpF/lBis8a3A3BE2b5NieIYbNSYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDE1WhcNMjUwNjAzMjAzNDE1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWisDAPCvJsgl/y26+UMtF6aqXMMhpfhDUdMaFpkvMQETVpy7xaQ95edxqSs0HVVHUZ5jAgJkX+OOlKaSTwnE2aOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU9jUAkXZg1VgT7fopPD4I8O2dzyMwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3dNwAAABAMASDBGAiEAnaQxKqrYV1LfY39CUFFFnqY54OAbAAbwZODT/OCdf4cCIQC9pjnmoMlJ6IJkb2ZJZnnvhkhnPAqcV88kxF/lxA+fjzAKBggqhkjOPQQDAwNnADBkAjAB++TkQwmSh/wKIyQprfGyd7/tlX0Z0ZWNqir7W6mxqyPmW6lG6EYA0IazvGSMs/UCMCHJRt/gPT1AtiufxgGuok5iuJLUNpw3anY7ACIt/4ed5qsDDfKM7A0KmKDVTz5dFw=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995264",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982255",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQCzDERW2YOQUGYpCKbm3mAF7kYjY1SCwZVg0zvlqj0MrgIgB7WE4F5gJiYUYOUJyG5a6pP0QjVbANe6kisZDHtuuXA="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107091002",
+                            "rootHash": "SWdOpBx5PKPNJx1Uk5o6ISjIn3Mmx7FSuZpPA3Qjljg=",
+                            "treeSize": "107091003",
+                            "hashes": [
+                                "KigTHKvqUuAmor9B52zCY9QPUnDyGC0i+Zde2gnk8xs=",
+                                "HEjI/3bmACEknkLW31CGhAusASJCyHPJRc1kSU/qF/o=",
+                                "2QDfuMxORCV6U4VT+zg/ndf6+ExmH7w85R8qUiKurNU=",
+                                "MBQq7l9RpJcImg3imhRpg4nfYje+guiJA8KvpNiOoJE=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107091003\nSWdOpBx5PKPNJx1Uk5o6ISjIn3Mmx7FSuZpPA3Qjljg=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAkIuG9cIRLqTCb12PR+F/nMUX7cEzacvmnxCfnetCikICIQDUqUlF4aNhhNa13zmrHgMf5DVT07zPosSb5SUXvrQ5xg==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI1MTRjYTE0ZWMzNTZlY2I3NzQ5YTdjMGExZWYxZWFjOWZkOWM2N2Q1N2FmNDgxMmNiMWYwODIyYjBkM2E4NWU4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURaTnB6VzFzeEdiMHovbithSGpxZDdpTU9DRmdEZ281Q1Mzb1NOblkrQXVBSWhBTW9jL2pFZURhS2J6dUlrcHYxUjk1OXNabXFoT3Q0aHNTaHFYd3VheFlLdyIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVha05EUVd4SFowRjNTVUpCWjBsVlVuQkdMMnhDYVhNNFlUTkJNMEpGTW1JMVRtbGxTVmxpVGxOWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JGTVZkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVVeFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZYYVhORVFWQkRka3B6WjJ3dmVUSTJLMVZOZEVZMllYRllUVTFvY0dab1JGVmtUV0VLUm5CcmRrMVJSVlJXY0hrM2VHRlJPVFZsWkhoeFUzTXdTRlpXU0ZWYU5XcEJaMHByV0N0UFQyeExZVk5VZDI1Rk1tRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlU1YWxWQkNtdFlXbWN4Vm1kVU4yWnZjRkJFTkVrNFR6SmtlbmxOZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpFNTNRVUZCUWtGTlFRcFRSRUpIUVdsRlFXNWhVWGhMY1hKWlZqRk1abGt6T1VOVlJrWkdibkZaTlRSUFFXSkJRV0ozV2s5RVZDOVBRMlJtTkdORFNWRkRPWEJxYm0xdlRXeEtDalpKU210aU1scEtXbTV1ZG1ocmFHNVFRWEZqVmpnNGEzaEdMMng0UVN0bWFucEJTMEpuWjNGb2EycFBVRkZSUkVGM1RtNUJSRUpyUVdwQlFpc3JWR3NLVVhkdFUyZ3ZkMHRKZVZGd2NtWkhlV1EzTDNSc1dEQmFNRnBYVG5GcGNqZFhObTE0Y1hsUWJWYzJiRWMyUlZsQk1FbGhlblpIVTAxekwxVkRUVU5JU2dwU2RDOW5VRlF4UVhScGRXWjRaMGQxYjJzMWFYVktURlZPY0hjellXNVpOMEZEU1hRdk5HVmtOWEZ6UkVSbVMwMDNRVEJMYlV0RVZsUjZOV1JHZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "UUyhTsNW7Ld0mnwKHvHqyf2cZ9V69IEssfCCKw06heg="
+                },
+                "signature": "MEYCIQDZNpzW1sxGb0z/n+aHjqd7iMOCFgDgo5CS3oSNnY+AuAIhAMoc/jEeDaKbzuIkpv1R959sZmqhOt4hsShqXwuaxYKw"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-win32.zip",
+        "sha256": "04ee686076d52a198ef6e671bba0d54683a2da0c230782ae16c950493d1bb9cc",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-win32.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "21a460c5b1fd2d791755e239dfbf1141",
+            "File Size": "9.2\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-win32.zip.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-win32.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-win32.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlCgAwIBAgIUBXUMK3QN3v0s9RKk06zyaJJREwEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDE2WhcNMjUwNjAzMjAzNDE2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnjwqLtv2jZGfnBPrtMTlrKu1JU1C8HLy+dj5Ol6r2Oh04Zuydt53DFyKUnc3Pe/N4Zjg8i1L2+MgyESaxNEILqOCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUZ/d/6YltHq62tllJVOJbKpKM3+IwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3dUUAAABAMARzBFAiEAk3ltouIx0MWoDkEj84jwmjM59V2xcxKDAbudVmm2ApoCIEVTYEtDCWn/P0rMmcv5q4rMLGKH+mZbwvR+XP5dcCfoMAoGCCqGSM49BAMDA2kAMGYCMQDB/9E1lmti88HQ38aiaiUhvyUv+iSxHF7/f0H8FIurwLW4nj7C2mGV3wMQt+X+N68CMQDHLdK+5KcGbaI9qm+vLDnSlF7v/sSm0jU3TH9FUKYdqqK6Q+ERPYbcGuxS8F8KdBg="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995293",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982257",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQC7OjMIXOz9z4zGVG8ofDw3BA6hIFPbqGkpqbK/6zVs7wIhAMFlTh+sfMEBhbfE+YAhV2d4PfAAoFWRCW2Caq0Ji0Ih"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107091031",
+                            "rootHash": "x8ZIxxZnbbsWI0tHH0NCCKmJFOErU3hvyKI99GBlrek=",
+                            "treeSize": "107091035",
+                            "hashes": [
+                                "RFNcMYQNdwv6ErTEU2f9Mvfp+fzk96nRyGdL50S8bdw=",
+                                "lqYLNK6+LCsSYYPAZKPZIwuMtYEFjBJTp7jXkxMAD34=",
+                                "8QKLkiHkvXpyvSWRvF32zXvpqY6ncsUOwZbXymFqo6U=",
+                                "9YZr/0IgUw6JapHSNhPnUpMelvmkq8DnvLKTG8E2OvI=",
+                                "MY9Cjw2GIqyTOFQr5oDzfdVgI5UZ9UNBxzp3mSXNAZs=",
+                                "9EDGv0xMio7fxkCk50td7mpHe9kBl/TdDVA74IPqGKI=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107091035\nx8ZIxxZnbbsWI0tHH0NCCKmJFOErU3hvyKI99GBlrek=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAnOOgx2UknFb9P1z3+fS2vozaiS2lcXSdBQFKmRsatZwIgdmNsoXNp/pOe/wYlLA9rHqj09ahR7DToQJtxtfubmAQ=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIwNGVlNjg2MDc2ZDUyYTE5OGVmNmU2NzFiYmEwZDU0NjgzYTJkYTBjMjMwNzgyYWUxNmM5NTA0OTNkMWJiOWNjIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUNHd2F4c2d2Kzhqd2RFdUNnanY3TjFyTDNpNTl3TGkzOVh4anRYRXJMNVR3SWdKRklDczh6YzNua2xNeDh0NHRTYWpXZWZzMzl5QUV2SG51eG92WVFxZkZnPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4RFowRjNTVUpCWjBsVlFsaFZUVXN6VVU0emRqQnpPVkpMYXpBMmVubGhTa3BTUlhkRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JGTWxkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVVeVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ1YW5keFRIUjJNbXBhUjJadVFsQnlkRTFVYkhKTGRURktWVEZET0VoTWVTdGthalVLVDJ3MmNqSlBhREEwV25WNVpIUTFNMFJHZVV0VmJtTXpVR1V2VGpSYWFtYzRhVEZNTWl0TlozbEZVMkY0VGtWSlRIRlBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZhTDJRdkNqWlpiSFJJY1RZeWRHeHNTbFpQU21KTGNFdE5NeXRKZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpGVlZRVUZCUWtGTlFRcFNla0pHUVdsRlFXc3piSFJ2ZFVsNE1FMVhiMFJyUldvNE5HcDNiV3BOTlRsV01uaGplRXRFUVdKMVpGWnRiVEpCY0c5RFNVVldWRmxGZEVSRFYyNHZDbEF3Y2sxdFkzWTFjVFJ5VFV4SFMwZ3JiVnBpZDNaU0sxaFFOV1JqUTJadlRVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeWEwRk5SMWxEVFZGRVFpODVSVEVLYkcxMGFUZzRTRkV6T0dGcFlXbFZhSFo1VlhZcmFWTjRTRVkzTDJZd1NEaEdTWFZ5ZDB4WE5HNXFOME15YlVkV00zZE5VWFFyV0N0T05qaERUVkZFU0FwTVpFc3JOVXRqUjJKaFNUbHhiU3QyVEVSdVUyeEdOM1l2YzFOdE1HcFZNMVJJT1VaVlMxbGtjWEZMTmxFclJWSlFXV0pqUjNWNFV6aEdPRXRrUW1jOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "BO5oYHbVKhmO9uZxu6DVRoOi2gwjB4KuFslQST0bucw="
+                },
+                "signature": "MEUCIQCGwaxsgv+8jwdEuCgjv7N1rL3i59wLi39XxjtXErL5TwIgJFICs8zc3nklMx8t4tSajWefs39yAEvHnuxovYQqfFg="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-arm64.zip",
+        "sha256": "3ad028e6cf16dc396734d6a0d685bc80c5e750dbe2922ec040150a00f9f0fd41",
+        "release_url": "https://www.python.org/downloads/release/python-3134/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-arm64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "fd3b26576f60ef44c75b3eb4ff4f437a",
+            "File Size": "9.7\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-arm64.zip.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-arm64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.4/python-3.13.4-embed-arm64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlGgAwIBAgIUMkIYz+/5KW9z8ABc+ZnN0I8IyjcwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMjAyNDEzWhcNMjUwNjAzMjAzNDEzWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEliUMvAu/fCl8AAA35BBk+nli1ag4p099IqvhxXnQFnjITcKTfwZ9PjG8Cawn+3KhhirMT0XyOiXT3x4cXudG5qOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUcA8hW+iV0pL0H3KIRd9rG9TPN3owHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXN3dHEwAABAMASDBGAiEA+dalvgwwYPSmhi3sAtwPuGy0AOdbV2s7GnSYtrDT0HkCIQCGWFt7Zs1tqMUpsVfNznpeImIYBMrkpAr94+UNYPimrTAKBggqhkjOPQQDAwNpADBmAjEAjfU4Rs5lXImi0MJcvleoy+nlUIDTAXW1LALWEduDqAg23f4JBO7NOZpTAvTQ+JK2AjEAvfANVoBj9xvubbbtn8bvwrFN0Ka9TuB/Kaqz3O2MrCwjrmE0Q4YCp4+EKZCrGNS5"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228995233",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748982253",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQCsOdiQM/Bng/1j0zply5JgKt42zt2C7Ao9xpTo3kmoiwIhAO0vdN7NN/x9BKxv70ZnWgTRNCRJTcncjxWHpYs0QyDT"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107090971",
+                            "rootHash": "RHGV7YrfT43uCXcXZzTqlXM/g7cQkP8b1jA3HYDHFiE=",
+                            "treeSize": "107090977",
+                            "hashes": [
+                                "1ngKwA5Ukx8eVUmWloWjAXYDPJ9y+PRxF0ShqxbBPyg=",
+                                "3oPDM6ZNKUWYvBlXmdvcfm+StfG172Q+cY1fq9N6f8o=",
+                                "D5nY3XRfEU3elKwP1hfTDCOxKAXSP2qbJmhZS0b++Kw=",
+                                "/3zRNUE6DvFX+e1zxthpDicifj4bYk1BIe8sMPu3pg0=",
+                                "swwHKGxoHJF4tqvOWc63g2k9qUxwq67L/uAvafn7JMk=",
+                                "UwPpZ6PRg2piGh4O6D5sf+i5bZn6NJsYCSz+M0scGWw=",
+                                "z3o+sKP570xMDDE+WG1tQ7/jLrscnDU8zO3w5a2cKY0=",
+                                "D9KSyfJ1Pdvf2CPvtkw4oCMv+d18yXdvJqENIFEgyOI=",
+                                "iAVK98ztKz+eVzHdv6s/r4Tg+0R0I3EqU4gAHE4VY+0=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107090977\nRHGV7YrfT43uCXcXZzTqlXM/g7cQkP8b1jA3HYDHFiE=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAxURYuaOvTa15LaTbbEBxzMnxlC/0rlqd1Ja/WKCAu1ECIQCgw4iNvYbOghGwtoZ0O+6oLyc+izIcqayrthBh9LpS5g==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIzYWQwMjhlNmNmMTZkYzM5NjczNGQ2YTBkNjg1YmM4MGM1ZTc1MGRiZTI5MjJlYzA0MDE1MGEwMGY5ZjBmZDQxIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJR2kzOTBDbUhhUWFrSTRrb1YxN2cwQjhRQjU2TDN0dzVnSlgyMjk0U3daVUFpQjE3RU9UNTl1QTl6SnR1bzlJZjN1TWJ3bFJDQVkzMG5jdTFvenQrRHVtM0E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4SFowRjNTVUpCWjBsVlRXdEpXWG9yTHpWTFZ6bDZPRUZDWXl0YWJrNHdTVGhKZVdwamQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTmFrRjVUa1JGZWxkb1kwNU5hbFYzVG1wQmVrMXFRWHBPUkVWNlYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZzYVZWTmRrRjFMMlpEYkRoQlFVRXpOVUpDYXl0dWJHa3hZV2MwY0RBNU9VbHhkbWdLZUZodVVVWnVha2xVWTB0VVpuZGFPVkJxUnpoRFlYZHVLek5MYUdocGNrMVVNRmg1VDJsWVZETjROR05ZZFdSSE5YRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZqUVRob0NsY3JhVll3Y0V3d1NETkxTVkprT1hKSE9WUlFUak52ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0U0elpFaEZkMEZCUWtGTlFRcFRSRUpIUVdsRlFTdGtZV3gyWjNkM1dWQlRiV2hwTTNOQmRIZFFkVWQ1TUVGUFpHSldNbk0zUjI1VFdYUnlSRlF3U0d0RFNWRkRSMWRHZERkYWN6RjBDbkZOVlhCelZtWk9lbTV3WlVsdFNWbENUWEpyY0VGeU9UUXJWVTVaVUdsdGNsUkJTMEpuWjNGb2EycFBVRkZSUkVGM1RuQkJSRUp0UVdwRlFXcG1WVFFLVW5NMWJGaEpiV2t3VFVwamRteGxiM2tyYm14VlNVUlVRVmhYTVV4QlRGZEZaSFZFY1VGbk1qTm1ORXBDVHpkT1QxcHdWRUYyVkZFclNrc3lRV3BGUVFwMlprRk9WbTlDYWpsNGRuVmlZbUowYmpoaWRuZHlSazR3UzJFNVZIVkNMMHRoY1hvelR6Sk5ja04zYW5KdFJUQlJORmxEY0RRclJVdGFRM0pIVGxNMUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "OtAo5s8W3DlnNNag1oW8gMXnUNviki7AQBUKAPnw/UE="
+                },
+                "signature": "MEQCIGi390CmHaQakI4koV17g0B8QB56L3tw5gJX2294SwZUAiB17EOT59uA9zJtuo9If3uMbwlRCAY30ncu1ozt+Dum3A=="
+            }
+        }
+    }
+]

--- a/versions/3.13.5.json
+++ b/versions/3.13.5.json
@@ -1,0 +1,656 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tgz",
+        "sha256": "e6190f52699b534ee203d9f417bdbca05a92f23e35c19c691a50ed2942835385",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "88dc0b8317cab6e46e8336995bcc577f",
+            "File Size": "28.1\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tgz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tgz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tgz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlGgAwIBAgIUZDU4irb7rmqCJ0T350Jnzn00qfEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMTc0NjEyWhcNMjUwNjExMTc1NjEyWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElNoqbq6XClGsLi274FRLAIrCe8OsErL2st0635eKYa0xM7hoC98uVxhzxubDHHfiLlYQwOx75Jn/YO+2T6KL9aOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU8MimmyZsiGjojwNI/hvaEX4CfNgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYBl7TAAABAMASDBGAiEArYKVqqV1r74zuLjzGkavrK3GmWTIpBbMVAK+6zKiX6UCIQDBhauemfugm5/OzrHH7RG3l1ZDNsEOfmu6KcGR/j1PvTAKBggqhkjOPQQDAwNpADBmAjEA4RYmU0qH5N92uVmtWb6gjpX5jpCg9kMNNCA2IMnreNFjWXIqSHgehGqwtc0s3dz1AjEAzlQQBY+TKc/EXwPDLLRqvKopkHLDwqNkL+3wRVW80aEiAF/SxCK6KJIpjjYP70kx"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235130218",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749663972",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQD/DJkwAQ8DRlnV+914gOz01MPOqse04gancym3eqLCAQIhAMEuTHAM58j0Ykoc72B4czoO47WAXLPUprLx4L9aJhx0"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113225956",
+                            "rootHash": "7yUEwPWD6BO0MoBUbBRDAhVqFiw67R9PaCi1Tx9X5Cs=",
+                            "treeSize": "113225957",
+                            "hashes": [
+                                "TIf3hS0x7RIJEGAt80iexPJnVm0lNciC1SjH0zK0Ang=",
+                                "yjeBOwQkduuVduL2B7ApNi8DGvJ0erlH42Dn0ctyIH4=",
+                                "JFszuU6GTqDpER9NxAWupPKVjoHVYtrgDj/lQ2jvFWQ=",
+                                "blaQ9Ug/ILxR31xTa4+XNHIUWy9c/IF/jM61iEhe4yg=",
+                                "Ho1rvGrV8vApgV6ObQmLHUFtPdLht0dxaKIMr2L227A=",
+                                "bUrfsqt1y90MYAQSa4N7IMFLQ58Gr3kyGuZsXADQmyk=",
+                                "zQYNyoYKqtevNhM4z5didetaiTZZe4Ydpenxywyp2HM=",
+                                "yB2hiozejE1yTbQwbDQpScNo2G9QaqtVTvrtSzcAWLk=",
+                                "ni+UOcPDIr1WWONf2Z1uda+A31LRXKpMYBvhb3MyUvI=",
+                                "jak2gEavHKki8uP+13+VibRhrrjlEQ57Cu6sFEmzL98=",
+                                "x/DbUcJZd7Krichz/nbTRqNRynFXkcgDj6/SVp3Xpa8=",
+                                "KL733V6m2mKaszPoebRYld3g+XcUSNldm6GnXG4M7kM=",
+                                "f42cOIPnrB9x+HYKZ+7UAkXKjk7k9ttvx1Mm5/glCwo=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113225957\n7yUEwPWD6BO0MoBUbBRDAhVqFiw67R9PaCi1Tx9X5Cs=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEA84N1uz886YVLgs7r9I6FOhMSRiF43lWoivF6JGoFoWMCIAsapI2lr3AjaJn/3gmm+IEd3GAoTA3X5tt9V4fsakmx\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJlNjE5MGY1MjY5OWI1MzRlZTIwM2Q5ZjQxN2JkYmNhMDVhOTJmMjNlMzVjMTljNjkxYTUwZWQyOTQyODM1Mzg1In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJSHZNOUlrRStEaVFmVHpLdXhNdVRhNmdSQjJKa21kaDloL0crem1TSU85MkFpQVNzM0xkRmhKdUNTaDQxODBPekNsUlEwa3dDamk5Z0IwUUt2bUJKYXFjZEE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4SFowRjNTVUpCWjBsVldrUlZOR2x5WWpkeWJYRkRTakJVTXpVd1NtNTZiakF3Y1daRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTlZHTXdUbXBGZVZkb1kwNU5hbFYzVG1wRmVFMVVZekZPYWtWNVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZzVG05eFluRTJXRU5zUjNOTWFUSTNORVpTVEVGSmNrTmxPRTl6UlhKTU1uTjBNRFlLTXpWbFMxbGhNSGhOTjJodlF6azRkVlo0YUhwNGRXSkVTRWhtYVV4c1dWRjNUM2czTlVwdUwxbFBLekpVTmt0TU9XRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlU0VFdsdENtMTVXbk5wUjJwdmFuZE9TUzlvZG1GRldEUkRaazVuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsQ2JEZFVRVUZCUWtGTlFRcFRSRUpIUVdsRlFYSlpTMVp4Y1ZZeGNqYzBlblZNYW5wSGEyRjJja3N6UjIxWFZFbHdRbUpOVmtGTEt6WjZTMmxZTmxWRFNWRkVRbWhoZFdWdFpuVm5DbTAxTDA5NmNraElOMUpITTJ3eFdrUk9jMFZQWm0xMU5rdGpSMUl2YWpGUWRsUkJTMEpuWjNGb2EycFBVRkZSUkVGM1RuQkJSRUp0UVdwRlFUUlNXVzBLVlRCeFNEVk9PVEoxVm0xMFYySTJaMnB3V0RWcWNFTm5PV3ROVGs1RFFUSkpUVzV5WlU1R2FsZFlTWEZUU0dkbGFFZHhkM1JqTUhNelpIb3hRV3BGUVFwNmJGRlJRbGtyVkV0akwwVllkMUJFVEV4U2NYWkxiM0JyU0V4RWQzRk9hMHdyTTNkU1ZsYzRNR0ZGYVVGR0wxTjRRMHMyUzBwSmNHcHFXVkEzTUd0NENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "5hkPUmmbU07iA9n0F728oFqS8j41wZxpGlDtKUKDU4U="
+                },
+                "signature": "MEQCIHvM9IkE+DiQfTzKuxMuTa6gRB2Jkmdh9h/G+zmSIO92AiASs3LdFhJuCSh4180OzClRQ0kwCji9gB0QKvmBJaqcdA=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz",
+        "sha256": "93e583f243454e6e9e4588ca2c2662206ad961659863277afcdb96801647d640",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "dbaa8833aa736eddbb18a6a6ae0c10fa",
+            "File Size": "21.8\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyjCCAlCgAwIBAgIUdRfsw3XxSwqBsRu/Ryhu0kfD1TEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMTc0NjIzWhcNMjUwNjExMTc1NjIzWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE616iCJ8T+boBEGZNSBgbHZ2TS6Bl7yRCs1F78fvUBWcO/fJl9vTWXF+oPaOhLWVl35iAkn1W04PDVWrqNpFntKOCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUlLnv2c6W2ETiqJdQsF9NjtUCVqEwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYBmnGAAABAMARzBFAiBDOyOIs3CL2AVMb7j6sHu3PYA8pOzJQNmm7J+zPIYzlgIhAK5GqY5j781IK5E7NTaGuPzwcj08xstDLULewS3KRwLBMAoGCCqGSM49BAMDA2gAMGUCMQDn2SkdZvHZZ6RKG8bIgPJdW+qMM9DNUmRm0/F+ePCPjMNwNUY/VQHqgsD4+m7FoX0CMAoIIxK3JZiKBFcP0oUNpnoZcZzZg/SeCkY6fePDlrRMMh5guyKUvMjXOIFREzNaRA=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235130253",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749663983",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIEXmlLAwKmFPqJl0qZIn6l9LeN1eFpo/O29cweVvcLM6AiEAkPbiV9MFAugYnKigfY2M6d4/IlgLMlamVTNMjYG1Ujc="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113225991",
+                            "rootHash": "+L93VCZOPa9BkLmARBWDo1xEWF+fT68+yQcazjpxAAU=",
+                            "treeSize": "113225992",
+                            "hashes": [
+                                "Rdu+myw6n6JxBUvJ8Q+8oqhqACFhkt/3w7I+DEesttk=",
+                                "RxFdYWKOAXBMCLz1xkC2n0/oY0PPGjB9g/1mK9X9Lpk=",
+                                "nRMGDo+FIXFJXJGmLI3xYofkA1BacK+jsaHI6Dah6SQ=",
+                                "P4PZCTzvD59p99NgLr2g5UaCSGBHniridbmhL+bTkOA=",
+                                "Ho1rvGrV8vApgV6ObQmLHUFtPdLht0dxaKIMr2L227A=",
+                                "bUrfsqt1y90MYAQSa4N7IMFLQ58Gr3kyGuZsXADQmyk=",
+                                "zQYNyoYKqtevNhM4z5didetaiTZZe4Ydpenxywyp2HM=",
+                                "yB2hiozejE1yTbQwbDQpScNo2G9QaqtVTvrtSzcAWLk=",
+                                "ni+UOcPDIr1WWONf2Z1uda+A31LRXKpMYBvhb3MyUvI=",
+                                "jak2gEavHKki8uP+13+VibRhrrjlEQ57Cu6sFEmzL98=",
+                                "x/DbUcJZd7Krichz/nbTRqNRynFXkcgDj6/SVp3Xpa8=",
+                                "KL733V6m2mKaszPoebRYld3g+XcUSNldm6GnXG4M7kM=",
+                                "f42cOIPnrB9x+HYKZ+7UAkXKjk7k9ttvx1Mm5/glCwo=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113225992\n+L93VCZOPa9BkLmARBWDo1xEWF+fT68+yQcazjpxAAU=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiBKR6/aQGwMRmyBmdgiaLd8393XQqJh41H6LIYA8Y6SYgIgDMucmAXZHwIDjA6YXg9k2vhoOuscGewoHiSomHsf+kg=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI5M2U1ODNmMjQzNDU0ZTZlOWU0NTg4Y2EyYzI2NjIyMDZhZDk2MTY1OTg2MzI3N2FmY2RiOTY4MDE2NDdkNjQwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJRWVnU0xnMVBzNmNEMkpNbTJzK1o4dzBzbGlMazY0SCtHeHQ2VFpRb1NIaUFpRUE1b2FmTTJhNlJqQSszUFpVdmNjUWNhQ0QzRVFsQ1hSdmI3d2x3SU9JQ1IwPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVha05EUVd4RFowRjNTVUpCWjBsVlpGSm1jM2N6V0hoVGQzRkNjMUoxTDFKNWFIVXdhMlpFTVZSRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTlZHTXdUbXBKZWxkb1kwNU5hbFYzVG1wRmVFMVVZekZPYWtsNlYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVUyTVRacFEwbzRWQ3RpYjBKRlIxcE9VMEpuWWtoYU1sUlROa0pzTjNsU1EzTXhSamNLT0daMlZVSlhZMDh2Wmtwc09YWlVWMWhHSzI5UVlVOW9URmRXYkRNMWFVRnJiakZYTURSUVJGWlhjbkZPY0VadWRFdFBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZzVEc1MkNqSmpObGN5UlZScGNVcGtVWE5HT1U1cWRGVkRWbkZGZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsQ2JXNUhRVUZCUWtGTlFRcFNla0pHUVdsQ1JFOTVUMGx6TTBOTU1rRldUV0kzYWpaelNIVXpVRmxCT0hCUGVrcFJUbTF0TjBvcmVsQkpXWHBzWjBsb1FVczFSM0ZaTldvM09ERkpDa3MxUlRkT1ZHRkhkVkI2ZDJOcU1EaDRjM1JFVEZWTVpYZFRNMHRTZDB4Q1RVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeVowRk5SMVZEVFZGRWJqSlRhMlFLV25aSVdsbzJVa3RIT0dKSloxQktaRmNyY1UxTk9VUk9WVzFTYlRBdlJpdGxVRU5RYWsxT2QwNVZXUzlXVVVoeFozTkVOQ3R0TjBadldEQkRUVUZ2U1FwSmVFc3pTbHBwUzBKR1kxQXdiMVZPY0c1dldtTmFlbHBuTDFObFEydFpObVpsVUVSc2NsSk5UV2cxWjNWNVMxVjJUV3BZVDBsR1VrVjZUbUZTUVQwOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "k+WD8kNFTm6eRYjKLCZiIGrZYWWYYyd6/NuWgBZH1kA="
+                },
+                "signature": "MEUCIEegSLg1Ps6cD2JMm2s+Z8w0sliLk64H+Gxt6TZQoSHiAiEA5oafM2a6RjA+3PZUvccQcaCD3EQlCXRvb7wlwIOICR0="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-macos11.pkg",
+        "sha256": "e754d6cae3f2810dd1818c1395a7ff50ce79ade3ec4887f7ce23ad581cc12e3a",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-macos11.pkg",
+            "Operating System": "macOS",
+            "Description": "for macOS 10.13 and later",
+            "MD5 Sum": "a0f126bf757effdbf7e1d0863a6f176f",
+            "File Size": "67.1\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-macos11.pkg.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-macos11.pkg.sigstore",
+            "SBOM": null
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyDCCAk+gAwIBAgIUBT58KcEF+ghV3UtBTqSZQry7rPswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTMwWhcNMjUwNjExMjE0NTMwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0/kkwYEYX+xqm/LyNQM1Zvz0oI49P9wjfTBfgZTgrEnpjrYO7XlZojkNrlrBJ8Imo90Tv8pUYvu9LuKaDFC1faOCAW4wggFqMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUOCxBvhY+WeKSGOLwQp2W99dYxOUwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOtqlgAABAMARjBEAiBadLSZxx+Xg6yztjDXz0XMJNOTbjpwZ0ZYqIniM24GoAIgWjHiI38YocpdOXQZsellM439XvoMKBv0aPW/gLthlRMwCgYIKoZIzj0EAwMDZwAwZAIwMqRh018tG1eUD6gQy/V7n+OB9HCfrEjX282JDwuwG4IJ8ZPAtuRo3LXPD/2HjES0AjAyVhzvS87u+WlJCgGhMc1HYK2jfxU56C6iwy/h/lIm9zJ+gZUcw+TOT3McfV3VWiI="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473242",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677731",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQC1/9KRgxAZUZm5cKrcTYct5234be51JtqtYa0pU1kGkgIhAPjY9lKRfSQF20Saw5no3xZ8z3gYB3/jmfraBAV0doO9"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113568980",
+                            "rootHash": "JIFITAv8q85Vi6PF366wxS6tUbT3H7DJJOClO1hTtqw=",
+                            "treeSize": "113568984",
+                            "hashes": [
+                                "bhdhh/+xvBihmwYmSn6XjWwCJ5shjC2mkRJoCWDSwEE=",
+                                "yrHUx5he+tFqTTCjXFp7ye3Ao0NG8NIRQdH3qL/gNpg=",
+                                "fJmsxaQqpMh1j4w4zJl9vGxcoynC/iPWz6z1f4q2OF0=",
+                                "CLf6CV3O3+9skt2iTjS0+XSeuaZIHyvpbjK2dhspExI=",
+                                "bZk505ibOD/Babfmi1UZLiixlv/Dh0hSgIa+UA1fHrk=",
+                                "SN/hv/w+6btGBzueVaIU2QvtE/pn0GoiWY8OR+ou4b0=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113568984\nJIFITAv8q85Vi6PF366wxS6tUbT3H7DJJOClO1hTtqw=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiA55gPtlBPNlZH5otIaX5AuLGl/ArAsXicQzr2S7Kur8wIgfCJyrXqk5bUqcD5luhTJnGha4iMftpp9WOHuzi8r9F4=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJlNzU0ZDZjYWUzZjI4MTBkZDE4MThjMTM5NWE3ZmY1MGNlNzlhZGUzZWM0ODg3ZjdjZTIzYWQ1ODFjYzEyZTNhIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJRzRTZEptSjRhOE1KQzFiMEhwTWZBZVE3NXRCZXEwUHh1MlpjSG1QZnZ6UUFpQkxEYWpMT3BhbTVYQTRjanVSdDRpbm1Hdk9WUi9pSkY1UzVRdElHaWVSMWc9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVSRU5EUVdzclowRjNTVUpCWjBsVlFsUTFPRXRqUlVZcloyaFdNMVYwUWxSeFUxcFJjbmszY2xCemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJOZDFkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkUxM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVV3TDJ0cmQxbEZXVmdyZUhGdEwweDVUbEZOTVZwMmVqQnZTVFE1VURsM2FtWlVRbVlLWjFwVVozSkZibkJxY2xsUE4xaHNXbTlxYTA1eWJISkNTamhKYlc4NU1GUjJPSEJWV1haMU9VeDFTMkZFUmtNeFptRlBRMEZYTkhkblowWnhUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZQUTNoQ0NuWm9XU3RYWlV0VFIwOU1kMUZ3TWxjNU9XUlplRTlWZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwcENaMjl5UW1kRlJVRmtXalZCWjFGRFFraHpSV1ZSUWpNS1FVaFZRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGRIRnNaMEZCUWtGTlFRcFNha0pGUVdsQ1lXUk1VMXA0ZUN0WVp6WjVlblJxUkZoNk1GaE5TazVQVkdKcWNIZGFNRnBaY1VsdWFVMHlORWR2UVVsblYycElhVWt6T0ZsdlkzQmtDazlZVVZwelpXeHNUVFF6T1ZoMmIwMUxRbll3WVZCWEwyZE1kR2hzVWsxM1EyZFpTVXR2V2tsNmFqQkZRWGROUkZwM1FYZGFRVWwzVFhGU2FEQXhPSFFLUnpGbFZVUTJaMUY1TDFZM2JpdFBRamxJUTJaeVJXcFlNamd5U2tSM2RYZEhORWxLT0ZwUVFYUjFVbTh6VEZoUVJDOHlTR3BGVXpCQmFrRjVWbWg2ZGdwVE9EZDFLMWRzU2tOblIyaE5ZekZJV1VzeWFtWjRWVFUyUXpacGQza3ZhQzlzU1cwNWVrb3JaMXBWWTNjclZFOVVNMDFqWmxZelZsZHBTVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "51TWyuPygQ3RgYwTlaf/UM55rePsSIf3ziOtWBzBLjo="
+                },
+                "signature": "MEQCIG4SdJmJ4a8MJC1b0HpMfAeQ75tBeq0Pxu2ZcHmPfvzQAiBLDajLOpam5XA4cjuRt4inmGvOVR/iJF5S5QtIGieR1g=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe",
+        "sha256": "c1cb40978b28f696b111c36034a1bdeda17d25e35c74a08ef5e5ff405a63fc20",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe",
+            "Operating System": "Windows",
+            "Description": "Recommended",
+            "MD5 Sum": "da9f24ae94e5b3491f3d92b07d34cc72",
+            "File Size": "27.5\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyjCCAlCgAwIBAgIUV4SY0rk8CZAq9/5Ks/iundbAebYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTMyWhcNMjUwNjExMjE0NTMyWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEm1BIgA4hUjc7gseXKG9ca1Ky8twr0UzILdywj57P2X8/ANW0mKakuQgiCyNivaKKcGvvEBnJpDydGgcJgJjIKKOCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUbgnvXAGQY03+QqBAr6w149ZZNe4wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOtyGgAABAMARzBFAiEAzuYMrG4xy/y/JQQAfCQUFMoLHWFXUaFDOcC7JPC1CBsCIHS1+nxWvzze4BlKJhGAV/wW3UjhnGEIdo7Uikk02ldRMAoGCCqGSM49BAMDA2gAMGUCMQC6jH1tsqBVMPZsvKqQjRa8D0SVPSaxkdKDS+7MpQSAwZFSuLKG1RX00YEnvmv0r+ACMGNdFtKZORM9gXkX7F8C2eAspwkH8iDj8tIffFiu2RFhZCqDlO1MO+mDXluor+1yXA=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473280",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677732",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCICG45OX45Be4btYLiI/jHfVpptgv3zj8m0ZKJr24D1dkAiEArUicGtyXSOgBqp43kmx1Al10HwMKjRDrzm1lJBJu3w8="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113569018",
+                            "rootHash": "w9a24wgwoxe9Co5/g4yBp6v/S9z3ndSA/1E6lIjFhuo=",
+                            "treeSize": "113569020",
+                            "hashes": [
+                                "m71zED1cPKAglIbNXNUS3oOeN9ErKfdObwWVBbNf4Qk=",
+                                "6qWVAuPoV40bLM3WTAeoUWXBC/aR5UWTkN5CWMb58mA=",
+                                "/gNJiKxf4RTXemv3gUIoNQ+jESSYwF/wnlkHp+j2qTU=",
+                                "E9XjANNWuOsgrdLlHR1Ic7CKRE3bIRovNj3hUgz9hoA=",
+                                "ozTC1nC90YtxsoTatV8XVogODnTo5YTdGkr7FWMcIwE=",
+                                "bZk505ibOD/Babfmi1UZLiixlv/Dh0hSgIa+UA1fHrk=",
+                                "SN/hv/w+6btGBzueVaIU2QvtE/pn0GoiWY8OR+ou4b0=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113569020\nw9a24wgwoxe9Co5/g4yBp6v/S9z3ndSA/1E6lIjFhuo=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiBW4ye/bh0pr4xgFOoDjVuChgl3MW/mxvNdESkN/b/npQIgH0EMQk2ayB8om1h9wk77euzDbx3yL2EyljmW2+HRgDg=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJjMWNiNDA5NzhiMjhmNjk2YjExMWMzNjAzNGExYmRlZGExN2QyNWUzNWM3NGEwOGVmNWU1ZmY0MDVhNjNmYzIwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURxYndERDduWTd6WWFHUkVySThUWk9HcENYM3pqamZ4bGpRUHJvZmd2a3pBSWhBTmV2ZjQ4cTRlUjF3UGluWjhaVXIreFBIR1B6LzhjbUZIVVZnOHQ1ZUZtQyIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVha05EUVd4RFowRjNTVUpCWjBsVlZqUlRXVEJ5YXpoRFdrRnhPUzgxUzNNdmFYVnVaR0pCWldKWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJOZVZkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkUxNVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ0TVVKSlowRTBhRlZxWXpkbmMyVllTMGM1WTJFeFMzazRkSGR5TUZWNlNVeGtlWGNLYWpVM1VESllPQzlCVGxjd2JVdGhhM1ZSWjJsRGVVNXBkbUZMUzJOSGRuWkZRbTVLY0VSNVpFZG5ZMHBuU21wSlMwdFBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZpWjI1MkNsaEJSMUZaTURNclVYRkNRWEkyZHpFME9WcGFUbVUwZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGRIbEhaMEZCUWtGTlFRcFNla0pHUVdsRlFYcDFXVTF5UnpSNGVTOTVMMHBSVVVGbVExRlZSazF2VEVoWFJsaFZZVVpFVDJORE4wcFFRekZEUW5ORFNVaFRNU3R1ZUZkMmVucGxDalJDYkV0S2FFZEJWaTkzVnpOVmFtaHVSMFZKWkc4M1ZXbHJhekF5YkdSU1RVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeVowRk5SMVZEVFZGRE5tcElNWFFLYzNGQ1ZrMVFXbk4yUzNGUmFsSmhPRVF3VTFaUVUyRjRhMlJMUkZNck4wMXdVVk5CZDFwR1UzVk1TMGN4VWxnd01GbEZiblp0ZGpCeUswRkRUVWRPWkFwR2RFdGFUMUpOT1dkWWExZzNSamhETW1WQmMzQjNhMGc0YVVScU9IUkpabVpHYVhVeVVrWm9Xa054Ukd4UE1VMVBLMjFFV0d4MWIzSXJNWGxZUVQwOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "wctAl4so9paxEcNgNKG97aF9JeNcdKCO9eX/QFpj/CA="
+                },
+                "signature": "MEYCIQDqbwDD7nY7zYaGRErI8TZOGpCX3zjjfxljQProfgvkzAIhANevf48q4eR1wPinZ8ZUr+xPHGPz/8cmFHUVg8t5eFmC"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5.exe",
+        "sha256": "a288ada6f394cc934c2e279b7b0cd5a51c0a4e69134d3cfc79839edc6bf27a7f",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5.exe",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "d3898d8ea3a1524b043458311446c0b3",
+            "File Size": "26.2\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5.exe.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/python-3.13.5.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyjCCAlCgAwIBAgIUWXX2qqpcWwSoAuU/TlhhgvASFd8wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTI1WhcNMjUwNjExMjE0NTI1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2Tnq3adpROdtgvr9JbWjQhY5s7f9D0cJuQQNY76PKXOwPqvnCI5QV9sxmFf8IOWNRIyEmVDGCLPKwq07fDaFzaOCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUfP/zZZPLdk//U3Mqb+7WlEdMsUIwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOtXywAABAMARzBFAiEAsxPiBmn5bImi1N7Wk1QvI7xtmQ8pyjWul2Kxu7FtxXoCICH/vZjykRv3uchhYQScihH4wKgx0jf/G71oKhOnAGqRMAoGCCqGSM49BAMDA2gAMGUCMQCgvy/n3OztFGKYuIVSoUABYmmqVULo8tuxqRkUghwH0UK0/lZNsNuo0BzubIhB20sCMA0vuyVnTPqjDKzLmXPQlP4e2OutwvrphYdoUiVTjM9De7cy1zJMJn6auNaF08oLxA=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473146",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677726",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEQCIDuSgcjWwkoRpTyX/2izRXXaXB8HXAD0ZY/8QbVH1k3qAiBD2Wq/dFAf1z9JlF6+wTSPJDdOzdYSnjY2TWFjTO6Ucw=="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113568884",
+                            "rootHash": "l9YI7RU9PWtvytczdVs96ovtmK/v6Bcs2O50Uxy6a5I=",
+                            "treeSize": "113568885",
+                            "hashes": [
+                                "U8oi7Adlmozvjvf9wnH4Xc4GrE9jLBqPKmwV+g4Ft8I=",
+                                "HO+NVus8J+pSpAW2mzHQIMkV5Nh7PlAIxog4thzlNH4=",
+                                "whksAZhDP5fA/o2d52Ke1CgJPsvZBBV3RaxSRSFQJsE=",
+                                "d6Y3/m+oho99U1AfUs3HYPWEpgTURMfklLpkFuF1zS8=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113568885\nl9YI7RU9PWtvytczdVs96ovtmK/v6Bcs2O50Uxy6a5I=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiBcCglcCjofFOdG7/g0ohMKZ86He3xiI/jlMKV/kqtYQQIgXLhIEjvNf9LY0a91iPoROlgGorJkT1DPF2G6BviiSng=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJhMjg4YWRhNmYzOTRjYzkzNGMyZTI3OWI3YjBjZDVhNTFjMGE0ZTY5MTM0ZDNjZmM3OTgzOWVkYzZiZjI3YTdmIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQmdWMzhZSTFjbWthV1VUUFREbTNIYVJHaSsrbVZ5ZkdjVHluenBCd29xcUFpQkFsZC9rMXppdTFabkhUL2J0MlBkeXhSdTVtZjlVaUNKSURpR0lmT21DeUE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVha05EUVd4RFowRjNTVUpCWjBsVlYxaFlNbkZ4Y0dOWGQxTnZRWFZWTDFSc2FHaG5ka0ZUUm1RNGQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJKTVZkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkVreFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVV5Vkc1eE0yRmtjRkpQWkhSbmRuSTVTbUpYYWxGb1dUVnpOMlk1UkRCalNuVlJVVTRLV1RjMlVFdFlUM2RRY1hadVEwazFVVlk1YzNodFJtWTRTVTlYVGxKSmVVVnRWa1JIUTB4UVMzZHhNRGRtUkdGR2VtRlBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZtVUM5NkNscGFVRXhrYXk4dlZUTk5jV0lyTjFkc1JXUk5jMVZKZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGRGaDVkMEZCUWtGTlFRcFNla0pHUVdsRlFYTjRVR2xDYlc0MVlrbHRhVEZPTjFkck1WRjJTVGQ0ZEcxUk9IQjVhbGQxYkRKTGVIVTNSblI0V0c5RFNVTklMM1phYW5sclVuWXpDblZqYUdoWlVWTmphV2hJTkhkTFozZ3dhbVl2UnpjeGIwdG9UMjVCUjNGU1RVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeVowRk5SMVZEVFZGRFozWjVMMjRLTTA5NmRFWkhTMWwxU1ZaVGIxVkJRbGx0YlhGV1ZVeHZPSFIxZUhGU2ExVm5hSGRJTUZWTE1DOXNXazV6VG5Wdk1FSjZkV0pKYUVJeU1ITkRUVUV3ZGdwMWVWWnVWRkJ4YWtSTGVreHRXRkJSYkZBMFpUSlBkWFIzZG5Kd2FGbGtiMVZwVmxScVRUbEVaVGRqZVRGNlNrMUtialpoZFU1aFJqQTRiMHg0UVQwOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "ooitpvOUzJNMLiebewzVpRwKTmkTTTz8eYOe3Gvyen8="
+                },
+                "signature": "MEQCIBgV38YI1cmkaWUTPTDm3HaRGi++mVyfGcTynzpBwoqqAiBAld/k1ziu1ZnHT/bt2PdyxRu5mf9UiCJIDiGIfOmCyA=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.exe",
+        "sha256": "0bfe8e690f34765b5c26328781fa722741e9a2170fbb754f73dd1fcad6c271d4",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.exe",
+            "Operating System": "Windows",
+            "Description": "Experimental",
+            "MD5 Sum": "75b8a99cfd9fd5c15771b598bc067385",
+            "File Size": "26.8\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.exe.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-arm64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlGgAwIBAgIUXr2RVB8OoKmbjdptd//JFPRfewIwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTM0WhcNMjUwNjExMjE0NTM0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKUSKq2p4g0imvY2+/Enax8DXhL0vntOQESKsYHL/8EWvKOxoh2y9WyRxVMiM13qwq8QEh57unaRCry6rK/QeJqOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUgGNxSSr0Ks0EFG/urZY+8OXf2AcwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOt4rwAABAMASDBGAiEArMRnij2teOOy2lKJxD5XK0nKapWCSVYNzI7FyNKCaroCIQCcxjaqDhz3RE76/MUNEzTRK89Cx1D5Odkjuu7dYiMRiTAKBggqhkjOPQQDAwNpADBmAjEAi8RQ94LqgDFVDa/ZfR/cZLr80Ps6j/U/Xpr2jNSCMG327Ti+apoVVOBs6G+V8QrIAjEApdtsmJ/LUs16vkMLFmCIb1dtqWt7kspL2N3UKJhWpyhnAUcYvVo7FeSfkQmEcri4"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473310",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677734",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEQCIFhlHowgkzCZg/cYSDRS4kjQvodmu9ua4oZ8Dp8bxqIkAiAhnOqIubnAmldrLgyPVeOaW+C13vg9go64/j4P22Dq+w=="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113569048",
+                            "rootHash": "qPEAEE9mWJFONcyeWe095Q76X+Ua7j/dp3iyTr8SITg=",
+                            "treeSize": "113569054",
+                            "hashes": [
+                                "xZR3VcqeTBQA+YxIMU3AG38eMFqe0N1je8OAMj6T5b0=",
+                                "MHW8A+pYB4NDx/Zx+9M6ofUHovb/WRRKbDhVFbOR7C4=",
+                                "PIwHPNDwEp0Jk7+labO+S7unNXG9Kq60HUuEMCzy8ZM=",
+                                "CnnAzYOfWF3IUYBwZrrVbJ/tKlyWbBgTPjzGGESE8TE=",
+                                "Q8n1kZp/9u7eWvalfGtjTOhc9LhX/i2WiW/hpHNmBBg=",
+                                "RLVWNhDSth+K65wqJgq50w3qYZqxUCsXKaTGdQWgSmo=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113569054\nqPEAEE9mWJFONcyeWe095Q76X+Ua7j/dp3iyTr8SITg=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEA1JaDonnvxq0hxh+VAhlpOYVUkZtVXux4TFa7QSYWYQMCIFFzuvnaKQGR2nDaxNR410CujWcMojZEfSYzO7ShXz0F\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIwYmZlOGU2OTBmMzQ3NjViNWMyNjMyODc4MWZhNzIyNzQxZTlhMjE3MGZiYjc1NGY3M2RkMWZjYWQ2YzI3MWQ0In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUUNwbWFJQWlheVNsRXQ5bHNjbDBUWFlYZUFIWHBOdFV6R29IdW1RRXI0bmVBSWhBTzYvWXk3NU1SZEhNRkJhMHRUd1U1akFXNFZ6MWFydVlNRGl5UFVIWlpmdyIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4SFowRjNTVUpCWjBsVldISXlVbFpDT0U5dlMyMWlhbVJ3ZEdRdkwwcEdVRkptWlhkSmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJOTUZkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkUwd1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZMVlZOTGNUSndOR2N3YVcxMldUSXJMMFZ1WVhnNFJGaG9UREIyYm5SUFVVVlRTM01LV1VoTUx6aEZWM1pMVDNodmFESjVPVmQ1VW5oV1RXbE5NVE54ZDNFNFVVVm9OVGQxYm1GU1EzSjVObkpMTDFGbFNuRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZuUjA1NENsTlRjakJMY3pCRlJrY3ZkWEphV1NzNFQxaG1Na0ZqZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGREUnlkMEZCUWtGTlFRcFRSRUpIUVdsRlFYSk5VbTVwYWpKMFpVOVBlVEpzUzBwNFJEVllTekJ1UzJGd1YwTlRWbGxPZWtrM1JubE9TME5oY205RFNWRkRZM2hxWVhGRWFIb3pDbEpGTnpZdlRWVk9SWHBVVWtzNE9VTjRNVVExVDJScmFuVjFOMlJaYVUxU2FWUkJTMEpuWjNGb2EycFBVRkZSUkVGM1RuQkJSRUp0UVdwRlFXazRVbEVLT1RSTWNXZEVSbFpFWVM5YVpsSXZZMXBNY2pnd1VITTJhaTlWTDFod2NqSnFUbE5EVFVjek1qZFVhU3RoY0c5V1ZrOUNjelpISzFZNFVYSkpRV3BGUVFwd1pIUnpiVW92VEZWek1UWjJhMDFNUm0xRFNXSXhaSFJ4VjNRM2EzTndUREpPTTFWTFNtaFhjSGxvYmtGVlkxbDJWbTgzUm1WVFptdFJiVVZqY21rMENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "C/6OaQ80dltcJjKHgfpyJ0HpohcPu3VPc90fytbCcdQ="
+                },
+                "signature": "MEYCIQCpmaIAiaySlEt9lscl0TXYXeAHXpNtUzGoHumQEr4neAIhAO6/Yy75MRdHMFBa0tTwU5jAW4Vz1aruYMDiyPUHZZfw"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip",
+        "sha256": "7d2650fd9d1b9d002d4a315d5f354247fd6a44f30517c7ef577b08f57a0fb6d9",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "370a345dbea8bbc1830a2385f24632d2",
+            "File Size": "10.4\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-amd64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlCgAwIBAgIUEKIdLi7GH1IZDeSWjikCeUwvDiEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTI3WhcNMjUwNjExMjE0NTI3WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnsutS/KD4yGq3NR215Z9gFPm5XOijnCVUUoSt3488VL1odIJGWczwsvEkrcitdQdJrMSjTVxxJxfk80fwTHNjKOCAW8wggFrMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUs3qsW1VcaeD7BnVup0lyW/qNFfgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOteZgAABAMARzBFAiB6CGY6rlOol9Vk1FJK5XmiQwdOjT4cedlXz19xZyygggIhAK04ZOK0ojLbdE63eDL3hXJYHY3VqZU+DItlRhbKExWVMAoGCCqGSM49BAMDA2kAMGYCMQDA0ARbzEUUbt5qqq9LixvT4mxicYXM3qQ1gMnvwkx0WEQwhiWeBCQpNh/SORJZJNgCMQDoJAmdoHv0K6gdY2IWkMhrI5j2794KXn/efDZXmcPZxG7hBuGVEUfFaqqsIpEI08c="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473167",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677727",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQCHC+L6HWdIE+eXs9WiAOtS1MHkz3E5dKXI8N1fN1k7AgIgO1NrvMCZ3xtSZ8doNuqQj0GaPvgMrtPgxjLyRpDDdcE="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113568905",
+                            "rootHash": "hejRshvZ515fPy7HowVhkZ3hZK0fPcLOdqf6TEMB6lI=",
+                            "treeSize": "113568913",
+                            "hashes": [
+                                "KOfYjsjDFvQ/vHDfDPUGEFybeoD/HDwccbv/i5O52qk=",
+                                "kTRJLVifM0iUCJOU6NgQHUAhQH49SI0kzRFCQ2ZRgjw=",
+                                "JwSX9DNhRr2kT4cHz3T95w4ZO2i3KuTV0cyZG4cYJrw=",
+                                "CjNHVl9HME5zQ+0Evlf0Tk2KNAm0sYv+xC7c1wWHFwk=",
+                                "tEsAjm+NbsllnqDVzvdhwMAaMlASsg5AIBlwDLXvifw=",
+                                "SN/hv/w+6btGBzueVaIU2QvtE/pn0GoiWY8OR+ou4b0=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113568913\nhejRshvZ515fPy7HowVhkZ3hZK0fPcLOdqf6TEMB6lI=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAMHSedumN62k1HhxOvhj9zyRNv9hXy385fFNcF85THtgIgcd2Xv3VpbIe4OSy1tCAbVluLNXLB4h3Elj0bCeOPgeA=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3ZDI2NTBmZDlkMWI5ZDAwMmQ0YTMxNWQ1ZjM1NDI0N2ZkNmE0NGYzMDUxN2M3ZWY1NzdiMDhmNTdhMGZiNmQ5In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUURNSHAyMGdIN0tkam84cEJjckRIMmFQMmt5aENPWGwyTEk2RUtOYkNWSVJ3SWdhcmp4azVmVGFMbEZyN01VL21pMGM0OERLVlpLS1Zpd0VaTmprbDk1citBPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4RFowRjNTVUpCWjBsVlJVdEpaRXhwTjBkSU1VbGFSR1ZUVjJwcGEwTmxWWGQyUkdsRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJKTTFkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkVrelYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ1YzNWMFV5OUxSRFI1UjNFelRsSXlNVFZhT1dkR1VHMDFXRTlwYW01RFZsVlZiMU1LZERNME9EaFdUREZ2WkVsS1IxZGplbmR6ZGtWcmNtTnBkR1JSWkVweVRWTnFWRlo0ZUVwNFptczRNR1ozVkVoT2FrdFBRMEZYT0hkblowWnlUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ6TTNGekNsY3hWbU5oWlVRM1FtNVdkWEF3YkhsWEwzRk9SbVpuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpRS1FVaFpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGRHVmFaMEZCUWtGTlFRcFNla0pHUVdsQ05rTkhXVFp5YkU5dmJEbFdhekZHU2tzMVdHMXBVWGRrVDJwVU5HTmxaR3hZZWpFNWVGcDVlV2RuWjBsb1FVc3dORnBQU3pCdmFreGlDbVJGTmpObFJFd3phRmhLV1VoWk0xWnhXbFVyUkVsMGJGSm9Za3RGZUZkV1RVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeWEwRk5SMWxEVFZGRVFUQkJVbUlLZWtWVlZXSjBOWEZ4Y1RsTWFYaDJWRFJ0ZUdsaldWaE5NM0ZSTVdkTmJuWjNhM2d3VjBWUmQyaHBWMlZDUTFGd1RtZ3ZVMDlTU2xwS1RtZERUVkZFYndwS1FXMWtiMGgyTUVzMloyUlpNa2xYYTAxb2NrazFhakkzT1RSTFdHNHZaV1pFV2xodFkxQmFlRWMzYUVKMVIxWkZWV1pHWVhGeGMwbHdSVWt3T0dNOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "fSZQ/Z0bnQAtSjFdXzVCR/1qRPMFF8fvV3sI9XoPttk="
+                },
+                "signature": "MEUCIQDMHp20gH7Kdjo8pBcrDH2aP2kyhCOXl2LI6EKNbCVIRwIgarjxk5fTaLlFr7MU/mi0c48DKVZKKViwEZNjkl95r+A="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-win32.zip",
+        "sha256": "809a2b0ca73765f4477e62007194b4d86b9b47a129d569162c6ae052d40ea84f",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-win32.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "589d9d4938b4e19c9fa4de83aad3d425",
+            "File Size": "9.2\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-win32.zip.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-win32.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-win32.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyjCCAlGgAwIBAgIUG1DMi5xnEcN+GxXg+Lzv4SKW2w0wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTI0WhcNMjUwNjExMjE0NTI0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENPlz7N+kXw36E89aWQO3VDpaiJe2rCvDZg/xPLdCwFT+FQolg2/GFujpEVzKtdByxSVJnWm1o7tnjLdc1/V/vqOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUQAzX35f9IryrUiIy0lTdmiEcO/swHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOtSbwAABAMASDBGAiEAmFibSwSVmKko93gzJKaQkBMAttUjNwF3IxhNvXyVT2cCIQDnCeU7tMKzoQOGCCQS85ewtSEv86zjY8OQNyIOJjbxszAKBggqhkjOPQQDAwNnADBkAjAGgZZuSUzZCHb369umDoG6SGER4tqPNbhrFExrXd7EzRsybS1cSaRNj2rZcJC6Ri8CMFVxak8LvoeHuVbvkzxv5Y4RhPjIvX9FGbmslSTEeLLC0Olbsd8hxU8gTPHTa/4jkg=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473119",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677724",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIFt+qlyfGVu9mAUsOy1efSN5enuRuBXazPVwVmhevY17AiEA6SK58asFCEa5CqlzeLFuLgxMQh+twG0QfV9LHo/jzXc="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113568857",
+                            "rootHash": "1O9ckEfNRT+np80QR0uB7jQ0A24iTFWa0YPn2gRPCBY=",
+                            "treeSize": "113568858",
+                            "hashes": [
+                                "ATxBltRkbuvROgJj5KfD09YNF21lN4COywJXIX+K+mQ=",
+                                "ScKuCV5i/A3IfIB86IE4Uh/LZPOAB/YoL2U3DgLm1b4=",
+                                "VhbFeb3ouTAsFANPGmFr2AxtGPzY01SklMtQfM6z70g=",
+                                "d6Y3/m+oho99U1AfUs3HYPWEpgTURMfklLpkFuF1zS8=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113568858\n1O9ckEfNRT+np80QR0uB7jQ0A24iTFWa0YPn2gRPCBY=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEA6jOOmX5e5VDH3WWf4ASu8Bmbs0e7eaZxJXCRQqc1q78CICYRhU1Ei4JZ/AHyf4HGNXYU+s3Ftbz3gEbFCEV/QoJu\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI4MDlhMmIwY2E3Mzc2NWY0NDc3ZTYyMDA3MTk0YjRkODZiOWI0N2ExMjlkNTY5MTYyYzZhZTA1MmQ0MGVhODRmIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUNXM0VFbDA5QXFRQ3JrZHVTL3Z6a0JUNXRtQkg5SWxqSnFLbitWZkIvaG5nSWdLSGUzL3pMWE82eklqc0gwd3hZRjQxZHByWEJZQVdtNFArVXNyWkpXYy8wPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVha05EUVd4SFowRjNTVUpCWjBsVlJ6RkVUV2sxZUc1RlkwNHJSM2hZWnl0TWVuWTBVMHRYTW5jd2QwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJKTUZkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkVrd1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZPVUd4Nk4wNHJhMWgzTXpaRk9EbGhWMUZQTTFaRWNHRnBTbVV5Y2tOMlJGcG5MM2dLVUV4a1EzZEdWQ3RHVVc5c1p6SXZSMFoxYW5CRlZucExkR1JDZVhoVFZrcHVWMjB4YnpkMGJtcE1aR014TDFZdmRuRlBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZSUVhwWUNqTTFaamxKY25seVZXbEplVEJzVkdSdGFVVmpUeTl6ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGRGTmlkMEZCUWtGTlFRcFRSRUpIUVdsRlFXMUdhV0pUZDFOV2JVdHJiemt6WjNwS1MyRlJhMEpOUVhSMFZXcE9kMFl6U1hob1RuWlllVlpVTW1ORFNWRkVia05sVlRkMFRVdDZDbTlSVDBkRFExRlRPRFZsZDNSVFJYWTRObnBxV1RoUFVVNTVTVTlLYW1KNGMzcEJTMEpuWjNGb2EycFBVRkZSUkVGM1RtNUJSRUpyUVdwQlIyZGFXblVLVTFWNldrTklZak0yT1hWdFJHOUhObE5IUlZJMGRIRlFUbUpvY2taRmVISllaRGRGZWxKemVXSlRNV05UWVZKT2FqSnlXbU5LUXpaU2FUaERUVVpXZUFwaGF6aE1kbTlsU0hWV1luWnJlbmgyTlZrMFVtaFFha2wyV0RsR1IySnRjMnhUVkVWbFRFeERNRTlzWW5Oa09HaDRWVGhuVkZCSVZHRXZOR3ByWnowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "gJorDKc3ZfRHfmIAcZS02GubR6Ep1WkWLGrgUtQOqE8="
+                },
+                "signature": "MEUCIQCW3EEl09AqQCrkduS/vzkBT5tmBH9IljJqKn+VfB/hngIgKHe3/zLXO6zIjsH0wxYF41dprXBYAWm4P+UsrZJWc/0="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-arm64.zip",
+        "sha256": "e355b81e8b58e294905ee3fde188e296337ee19b9a42bea8735298914fa3e4b0",
+        "release_url": "https://www.python.org/downloads/release/python-3135/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-arm64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "0d2b5391a1df1319242f17a8339b8bc6",
+            "File Size": "9.7\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-arm64.zip.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-arm64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.13.5/python-3.13.5-embed-arm64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICyzCCAlGgAwIBAgIUYHbaGgAdltBkRXWqYYTaiad/2/0wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjExMjEzNTI4WhcNMjUwNjExMjE0NTI4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfsxZNbMY4rOgIq0gKdwhQhYWeEnJ6XR0ROOKaf2UyIbfzaoFRaHeJcG6AMcQWW63dk1maUum2jrwx92g93aV+KOCAXAwggFsMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU9lSi6MrzuRwkctonz8Oz0kG+2vwwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERdGhvbWFzQHB5dGhvbi5vcmcwKQYKKwYBBAGDvzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMCsGCisGAQQBg78wAQgEHQwbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGLBgorBgEEAdZ5AgQCBH0EewB5AHcA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXYOtk0AAABAMASDBGAiEAilr3EOsc6oHLEqMU58noXx2Pp37D2jO3qtUaZZyU+eoCIQCt0ncnp5LXax/lMAgVoh2XPeyCrzY2HnTeU5w1ZwIaazAKBggqhkjOPQQDAwNoADBlAjEAyp/b7pUqncc4tV5X0aIU7UQY22re6cw55zNsfBbd3B1wzJrikKylkdJRD0LqYM3dAjBOLY5iy9IgPSF9Zuz646l2Tqjxft3OcRi2TYHWM/TUWpMEdFFV94XTiZMdEdNbBX0="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "235473206",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1749677729",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQCFR9j1kVYjyfwn55tHpFwSXI/f4gITnkVX47uSu0rBSAIhAO6PW4W/dHf3z59ePvDV30/ZUf/kxDDMv7rbrDtJHEAx"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "113568944",
+                            "rootHash": "ZvEL2IS3pOId3X3MTB+oeBf5nR3PP6B4ofN/phgpNNM=",
+                            "treeSize": "113568946",
+                            "hashes": [
+                                "fHm9LA56xxhK5Vf3cnU35eViv7BoOrWjLBqBz3Hzq40=",
+                                "5JNHuKviKtxN6bEpDuCj7QAT902thMBbr6A7gex2URs=",
+                                "PYym72UV6VqfzJChNPybhrw5Bg5c3sWlIMKJNKwca88=",
+                                "SN/hv/w+6btGBzueVaIU2QvtE/pn0GoiWY8OR+ou4b0=",
+                                "BqjrmrlxRPQJ06A7qvmy2B+FP0vRgzMIAZKGObKvkUo=",
+                                "+Y0mR7AGYz6ZXrVe9AxK3gkJyPjU73nRwcqGsZeFG4E=",
+                                "wNfwVji8HsRrrT0nIAUBIARy44MUXyOeU6otLNEPhtM=",
+                                "hhztmzTbqMaxbSCe5qoFzc5ZUbYntzMH4EUUUUnECXs=",
+                                "8qOdCC859w/6flFKbs8gB6TMCRmG4SgPKTIJgYsFkYc=",
+                                "Y1UswsJjNMZZ9dylM56z7fShRdrs2DvThO5ZpANA3fk=",
+                                "TLTmY56Wxqq2zecGn+fhFX/HEwZTGtN72fFgxhAsO0I=",
+                                "G4CdPz/xjoqWI4G874tZWPeP98DJpseyihrtz0ivBtU=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n113568946\nZvEL2IS3pOId3X3MTB+oeBf5nR3PP6B4ofN/phgpNNM=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiBRMM8PwWls1Qn92rLN9t77ECc+uzkdr0CM+96HfD280QIgTxqPEd06A1b4Ybs1eOUQvMyKVLjY5r4cwMyGQficnSg=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJlMzU1YjgxZThiNThlMjk0OTA1ZWUzZmRlMTg4ZTI5NjMzN2VlMTliOWE0MmJlYTg3MzUyOTg5MTRmYTNlNGIwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQkh2Vlo0bkIyT0Fub0d4ZzNGL2p6RVJvdFVQcGxFWFZGa09YN1hKbjllU0FpQk1idC9OY1JnY2NMMzJhdlFvQVZteGorUjFIS3FBK0tpbTI2ZVBEUk5XNUE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjVla05EUVd4SFowRjNTVUpCWjBsVldVaGlZVWRuUVdSc2RFSnJVbGhYY1ZsWlZHRnBZV1F2TWk4d2QwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlhoTmFrVjZUbFJKTkZkb1kwNU5hbFYzVG1wRmVFMXFSVEJPVkVrMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZtYzNoYVRtSk5XVFJ5VDJkSmNUQm5TMlIzYUZGb1dWZGxSVzVLTmxoU01GSlBUMHNLWVdZeVZYbEpZbVo2WVc5R1VtRklaVXBqUnpaQlRXTlJWMWMyTTJSck1XMWhWWFZ0TW1weWQzZzVNbWM1TTJGV0swdFBRMEZZUVhkblowWnpUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlU1YkZOcENqWk5jbnAxVW5kclkzUnZibm80VDNvd2EwY3JNblozZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1pFZG9kbUpYUm5wUlNFSTFaRWRvZG1KcE5YWmpiV04zUzFGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGaVlVaFNNR05JVFRaTWVUbG9XVEpPZG1SWE5UQmplVFZ1WWpJNWJtSkhWWFZaTWpsMFRVTnpSME5wYzBkQlVWRkNaemM0ZDBGUlowVklVWGRpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxSlIweENaMjl5UW1kRlJVRmtXalZCWjFGRFFrZ3dSV1YzUWpVS1FVaGpRVE5VTUhkaGMySklSVlJLYWtkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIV0ZsUGRHc3dRVUZCUWtGTlFRcFRSRUpIUVdsRlFXbHNjak5GVDNOak5tOUlURVZ4VFZVMU9HNXZXSGd5VUhBek4wUXlhazh6Y1hSVllWcGFlVlVyWlc5RFNWRkRkREJ1WTI1d05VeFlDbUY0TDJ4TlFXZFdiMmd5V0ZCbGVVTnllbGt5U0c1VVpWVTFkekZhZDBsaFlYcEJTMEpuWjNGb2EycFBVRkZSUkVGM1RtOUJSRUpzUVdwRlFYbHdMMklLTjNCVmNXNWpZelIwVmpWWU1HRkpWVGRWVVZreU1uSmxObU4zTlRWNlRuTm1RbUprTTBJeGQzcEtjbWxyUzNsc2EyUktVa1F3VEhGWlRUTmtRV3BDVHdwTVdUVnBlVGxKWjFCVFJqbGFkWG8yTkRac01sUnhhbmhtZEROUFkxSnBNbFJaU0ZkTkwxUlZWM0JOUldSR1JsWTVORmhVYVZwTlpFVmtUbUpDV0RBOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "41W4HotY4pSQXuP94YjiljN+4ZuaQr6oc1KYkU+j5LA="
+                },
+                "signature": "MEQCIBHvVZ4nB2OAnoGxg3F/jzERotUPplEXVFkOX7XJn9eSAiBMbt/NcRgccL32avQoAVmxj+R1HKqA+Kim26ePDRNW5A=="
+            }
+        }
+    }
+]

--- a/versions/3.14.0b2.json
+++ b/versions/3.14.0b2.json
@@ -1,0 +1,643 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tgz",
+        "sha256": "395e0daf993ddd6010dddef9ac6851996f69c2681a88c20190fa0dfe3e633930",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "ff637c39ab017ef75435f2bad5f02085",
+            "File Size": "29.1\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tgz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tgz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlSgAwIBAgIUNw/YgvFdoBx3Rl7CEOJcPxUxs7swCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjQzWhcNMjUwNTI2MTkwMjQzWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE93Ev4wkyZADUWILYCSL34nY72Yu5aGUgIzi0AIjVts5mo6UHJDn1pDG2kcby/zWlowUwWH6d9iKQRcI2PRExOKOCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU3ZicSG9Z/fYaq+pATW0mcIlO6uMwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wosMAAAQDAEcwRQIgKFPvUCOjvY57+hV2AgHk9d5fnlrFNikha3yFySzh2vQCIQDJ0Dh1THwYDWDkphoroyYBVX0JJbi2Y6B4oSvHsfz78jAKBggqhkjOPQQDAwNoADBlAjEAjPuhjIVIDOa0JIXDdGmBVop+UdgzMfpmMzQWx1h62LpwYBx0JQSUbOhXzvbUrF6QAjBC8ldhT1dhxe8IjAIsqQs0+5lY12+1ZbMJegq8vUrs7uWWZ4P3G78p8xu7bckBj7g="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085160",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285563",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIEUAuV3WnRyTSEg1Fyw5IFVact0mu/bmEkPWOF9MAkSzAiEA6Y6BSl0eMbsUrVqdmpXGZxNFC4hxvE17IhC5A1wsMp8="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180898",
+                            "rootHash": "6olRb0fD32JS4eP+kD1jVmbGMJmp429g+CxcLqvN/UM=",
+                            "treeSize": "98180899",
+                            "hashes": [
+                                "kteAb/mgqo608ZYiOPuiRng7GlIimteLv2IdmaIyMDE=",
+                                "3pI6V71WkxutIHjM0WkuBRhQdfcH4rIgtz/Eg3NETUo=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180899\n6olRb0fD32JS4eP+kD1jVmbGMJmp429g+CxcLqvN/UM=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAuUR/dngCzGnnGJKZZPAI2HKxDdvKkYDDCWIRlyTogVQCIQCGg39QkGBzDLGdFpC6f9hwc/5KRzhOQ5Gv66EAczkKzA==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIzOTVlMGRhZjk5M2RkZDYwMTBkZGRlZjlhYzY4NTE5OTZmNjljMjY4MWE4OGMyMDE5MGZhMGRmZTNlNjMzOTMwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJQW92eTl5V3hXOU1ka2pNN2l1NnNyeXVNNnQvMVpYTTlWUGFCVE1mdW9rdUFpRUFoTWljTVMxSk9IbzhiWDE3UzB4bWJlWUpmdjN2K3lZVUIwY3dzWGlFeU00PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVlRuY3ZXV2QyUm1SdlFuZ3pVbXczUTBWUFNtTlFlRlY0Y3pkemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BSZWxkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxGNlYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVU1TTBWMk5IZHJlVnBCUkZWWFNVeFpRMU5NTXpSdVdUY3lXWFUxWVVkVlowbDZhVEFLUVVscVZuUnpOVzF2TmxWSVNrUnVNWEJFUnpKclkySjVMM3BYYkc5M1ZYZFhTRFprT1dsTFVWSmpTVEpRVWtWNFQwdFBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlV6V21sakNsTkhPVm92WmxsaGNTdHdRVlJYTUcxalNXeFBOblZOZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zYjNOTlFRcEJRVkZFUVVWamQxSlJTV2RMUmxCMlZVTlBhblpaTlRjcmFGWXlRV2RJYXpsa05XWnViSEpHVG1scmFHRXplVVo1VTNwb01uWlJRMGxSUkVvd1JHZ3hDbFJJZDFsRVYwUnJjR2h2Y205NVdVSldXREJLU21KcE1sazJRalJ2VTNaSWMyWjZOemhxUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFSVUVLYWxCMWFHcEpWa2xFVDJFd1NrbFlSR1JIYlVKV2IzQXJWV1JuZWsxbWNHMU5lbEZYZURGb05qSk1jSGRaUW5nd1NsRlRWV0pQYUZoNmRtSlZja1kyVVFwQmFrSkRPR3hrYUZReFpHaDRaVGhKYWtGSmMzRlJjekFyTld4Wk1USXJNVnBpVFVwbFozRTRkbFZ5Y3pkMVYxZGFORkF6UnpjNGNEaDRkVGRpWTJ0Q0NtbzNaejBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "OV4Nr5k93WAQ3d75rGhRmW9pwmgaiMIBkPoN/j5jOTA="
+                },
+                "signature": "MEUCIAovy9yWxW9MdkjM7iu6sryuM6t/1ZXM9VPaBTMfuokuAiEAhMicMS1JOHo8bX17S0xmbeYJfv3v+yYUB0cwsXiEyM4="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tar.xz",
+        "sha256": "7ac9e84844bbc0a5a8f1f79a37a68b3b8caf2a58b4aa5999c49227cb36e70ea6",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "fb523c0bfe2aad21faa597311fe8b635",
+            "File Size": "22.5\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tar.xz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b2.tar.xz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzzCCAlWgAwIBAgIUChCDgQHRA1Igh/Ojbrpft+lgXo0wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjQ2WhcNMjUwNTI2MTkwMjQ2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECYjq5SRuvoZAvtJJ46ssKwhHC3HccF4i89/Q+yVu7kRlvttqzyjIgGeGI9WktRWOg78H0sIyvrEPScz7oHDVoaOCAXQwggFwMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUkCdI16aHO1xp5qoJifJvbKtEQKkwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wr2IAAAQDAEgwRgIhAJdMsBp/pjt043ZGHTzWw0gKmESRde7hNMQAb01FgjLIAiEA1T1YubIaj37yqL2pr/U12BLz9AraMLX2kSq9hw/Qg3swCgYIKoZIzj0EAwMDaAAwZQIxAIJo6hW9immJWSAGq0HPgKR+1b6KlIyJFosJp0ZocowP6VRr/OwQiuEXSRLwSLdI6gIwPP9ftNP5ikQCEhH6HDonHHb9HnHr/oAlYM+ivbRH+0x6HkYz8K1SH60Emy3sHBxT"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085169",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285567",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQCyGbx3XopZRmq6mmrCkhoQJvuRqR62giVmWtPvosANigIger0MkeXASzno5NKaUJwaTXlh4abtGBPsBsCDDmTV/38="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180907",
+                            "rootHash": "llBJk8Br31u8BNoIfOK++L8lwcRZXa0BM5VW7xu6HCE=",
+                            "treeSize": "98180908",
+                            "hashes": [
+                                "42WGfIQDj3m2U/fVjB7Kyjv8Yf1A1/k7HgcVf667qN8=",
+                                "cFUMpcTRO5yJiqUSGH0W+rx8e6FmwwwQMYk9HXcMF50=",
+                                "5cl6PeGOxk8ylkXyrKi8eGCyPTUAl8vlR0mhpWokrSY=",
+                                "3pI6V71WkxutIHjM0WkuBRhQdfcH4rIgtz/Eg3NETUo=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180908\nllBJk8Br31u8BNoIfOK++L8lwcRZXa0BM5VW7xu6HCE=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEA2i4Ql6CVpt7gnMTP5tWrN6p+mx3YIs8VZCuZ9nAr2csCIBGzsWrMsQCjhbOwLP6ZgHRCkv/eHf1lzgG/B8EmO6ck\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3YWM5ZTg0ODQ0YmJjMGE1YThmMWY3OWEzN2E2OGIzYjhjYWYyYTU4YjRhYTU5OTljNDkyMjdjYjM2ZTcwZWE2In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUURzVmF2REhzWnRkc3cyRk9jZGVvS2g0QWdxSlBkVHVaKy9WdjNBdWdIQ3dnSWdPT3dQK3B3dzFoaHlwUkE5QlYrS1c5bHJIeHNhWWJmbEhjZGgyTUd0ODZzPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZla05EUVd4WFowRjNTVUpCWjBsVlEyaERSR2RSU0ZKQk1VbG5hQzlQYW1KeWNHWjBLMnhuV0c4d2QwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BSTWxkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxFeVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZEV1dweE5WTlNkWFp2V2tGMmRFcEtORFp6YzB0M2FFaERNMGhqWTBZMGFUZzVMMUVLSzNsV2RUZHJVbXgyZEhSeGVubHFTV2RIWlVkSk9WZHJkRkpYVDJjM09FZ3djMGw1ZG5KRlVGTmplamR2U0VSV2IyRlBRMEZZVVhkblowWjNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZyUTJSSkNqRTJZVWhQTVhod05YRnZTbWxtU25aaVMzUkZVVXRyZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVhkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWprS1FraHpRV1ZSUWpOQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zY2pKSlFRcEJRVkZFUVVWbmQxSm5TV2hCU21STmMwSndMM0JxZERBME0xcEhTRlI2VjNjd1owdHRSVk5TWkdVM2FFNU5VVUZpTURGR1oycE1TVUZwUlVFeFZERlpDblZpU1dGcU16ZDVjVXd5Y0hJdlZURXlRa3g2T1VGeVlVMU1XREpyVTNFNWFIY3ZVV2N6YzNkRFoxbEpTMjlhU1hwcU1FVkJkMDFFWVVGQmQxcFJTWGdLUVVsS2J6Wm9WemxwYlcxS1YxTkJSM0V3U0ZCblMxSXJNV0kyUzJ4SmVVcEdiM05LY0RCYWIyTnZkMUEyVmxKeUwwOTNVV2wxUlZoVFVreDNVMHhrU1FvMlowbDNVRkE1Wm5ST1VEVnBhMUZEUldoSU5raEViMjVJU0dJNVNHNUljaTl2UVd4WlRTdHBkbUpTU0Nzd2VEWklhMWw2T0VzeFUwZzJNRVZ0ZVROekNraENlRlFLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "esnoSES7wKWo8feaN6aLO4yvKli0qlmZxJInyzbnDqY="
+                },
+                "signature": "MEUCIQDsVavDHsZtdsw2FOcdeoKh4AgqJPdTuZ+/Vv3AugHCwgIgOOwP+pww1hhypRA9BV+KW9lrHxsaYbflHcdh2MGt86s="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-macos11.pkg",
+        "sha256": "0575ac9fd561e6a0e7f84ea7b930ffd3e850eba2c0e3de0c3d6bf23522ffe149",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-macos11.pkg",
+            "Operating System": "macOS",
+            "Description": "for macOS 10.13 and later",
+            "MD5 Sum": "260b82c8a4bf19d5dab8e3db9a1cad6c",
+            "File Size": "70.9\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-macos11.pkg.sigstore",
+            "SBOM": null
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzzCCAlWgAwIBAgIUeh1zq7mSmeTzxddNf3Did7i/DrMwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjM4WhcNMjUwNTI2MTkwMjM4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpFCDj7io71m2O4TzXoLsHH6TqnGEWmNG2BXR3P4MjaRKsJ/adHHuREjZFOs+523p/y0fTddxHo19o7rI7YffnKOCAXQwggFwMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU8c/cWWe6Y9+pyaGFX1DRWgdEpzgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wjj8AAAQDAEgwRgIhAJVV/2R6903KjK1z2v7H7QbnBuiPSL8XK8Pds2pm4WUhAiEAysOIU+8X8NE15N0YWCifrAWt/4pnkTiht8zxikZ1Mc4wCgYIKoZIzj0EAwMDaAAwZQIxAMQ5UJ+yKC0GN9CMsGyi6/lt92cDI7lRm2+NL0Unwu62XccyYwenwZKusEdDKhdmZAIwbs34UaJqOpZUhImS3c/GlU0eJPQlFoGryVZ5kAQJh9f3qZWkDHw80Mndp3YvrfvN"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085142",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285558",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQD5w4vxS9/V2w1ect4QaSjR25VAJCW4chJeZBRjGAn4YgIgY1We+Mbvzv+cG8vZn3cK9icCThLGlXR22ANar0nvpWo="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180880",
+                            "rootHash": "Ctkxv64KANZ/JIH9fjd2XMVg2hDLtkoipZDhix26GSs=",
+                            "treeSize": "98180882",
+                            "hashes": [
+                                "6paY7u24rLpBeneZUOud6yydOgpqELWjHv+ZMiGbjGw=",
+                                "cl4Fbo4wB4YQz3beedRg8C7iXEHrxUZi+wUHQBBaq48=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180882\nCtkxv64KANZ/JIH9fjd2XMVg2hDLtkoipZDhix26GSs=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiAFyOlGZPU1t4xCDD1RsDeVcCRQZfMDfktstiJhhUPS+gIhANSO0Y/WzjzMj3h4/WdurahF5kGKCLp2LGHyVjVen8XZ\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIwNTc1YWM5ZmQ1NjFlNmEwZTdmODRlYTdiOTMwZmZkM2U4NTBlYmEyYzBlM2RlMGMzZDZiZjIzNTIyZmZlMTQ5In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJQXc2K00wR25jN05oVXJZTlVDYnB0WDBTNlkyeVZpWmk4eHlMaURoUVR4WkFpRUFwSGVJRXQwSHF5VkRvNEo4OXQ2Y3RUOTFzeGhDZHNubVBzREtWUmxKSkpjPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZla05EUVd4WFowRjNTVUpCWjBsVlpXZ3hlbkUzYlZOdFpWUjZlR1JrVG1ZelJHbGtOMmt2UkhKTmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BOTkZkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWswMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ3UmtORWFqZHBiemN4YlRKUE5GUjZXRzlNYzBoSU5sUnhia2RGVjIxT1J6SkNXRklLTTFBMFRXcGhVa3R6U2k5aFpFaElkVkpGYWxwR1QzTXJOVEl6Y0M5NU1HWlVaR1I0U0c4eE9XODNja2szV1dabWJrdFBRMEZZVVhkblowWjNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlU0WXk5akNsZFhaVFpaT1N0d2VXRkhSbGd4UkZKWFoyUkZjSHBuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVhkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWprS1FraHpRV1ZSUWpOQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zYW1vNFFRcEJRVkZFUVVWbmQxSm5TV2hCU2xaV0x6SlNOamt3TTB0cVN6RjZNblkzU0RkUlltNUNkV2xRVTB3NFdFczRVR1J6TW5CdE5GZFZhRUZwUlVGNWMwOUpDbFVyT0ZnNFRrVXhOVTR3V1ZkRGFXWnlRVmQwTHpSd2JtdFVhV2gwT0hwNGFXdGFNVTFqTkhkRFoxbEpTMjlhU1hwcU1FVkJkMDFFWVVGQmQxcFJTWGdLUVUxUk5WVktLM2xMUXpCSFRqbERUWE5IZVdrMkwyeDBPVEpqUkVrM2JGSnRNaXRPVERCVmJuZDFOakpZWTJONVdYZGxibmRhUzNWelJXUkVTMmhrYlFwYVFVbDNZbk16TkZWaFNuRlBjRnBWYUVsdFV6TmpMMGRzVlRCbFNsQlJiRVp2UjNKNVZsbzFhMEZSU21nNVpqTnhXbGRyUkVoM09EQk5ibVJ3TTFsMkNuSm1kazRLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "BXWsn9Vh5qDn+E6nuTD/0+hQ66LA494MPWvyNSL/4Uk="
+                },
+                "signature": "MEUCIAw6+M0Gnc7NhUrYNUCbptX0S6Y2yViZi8xyLiDhQTxZAiEApHeIEt0HqyVDo4J89t6ctT91sxhCdsnmPsDKVRlJJJc="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-amd64.exe",
+        "sha256": "279b1d0e2b1b6cece6f03e49218aacccfd10367e07b785edeb1d4135507434c1",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-amd64.exe",
+            "Operating System": "Windows",
+            "Description": "Recommended",
+            "MD5 Sum": "0fc9d2cba216091f1615cfc08fdf65d1",
+            "File Size": "28.4\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-amd64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-amd64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzTCCAlOgAwIBAgIUEZ1MqFpWoiSdBR9J6MR3M7wEuyAwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjM2WhcNMjUwNTI2MTkwMjM2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPplGacYqTwqN+5GgICRVC6QxFqeq7DcSmvuDphXhDS6fIgvlzAMeiZlgLw+eVZKTLRXjB2sWck+Av8u+/oFX16OCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUJ+OBKI/ec2BzHQSDKWEEqwBusQAwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wh5IAAAQDAEYwRAIgAWso/enrMyJoNhDLlBvDG3IwDSQby/h3Ai5reifvAmgCIBj5/eGp3DrlQoBnuIA99/7SNDY50mESaTeXpL5TvsM2MAoGCCqGSM49BAMDA2gAMGUCMQDEZYtnvx+UZ7NW3S+X48AAUknnxfoAHEjYyUhrhQrA9jicvOTftN2n2UUaxiTn34YCMAEvuT4o1CJqP7lMRWqGFcDCz5DpnED2Vz+B2cYmjRyzcqi5eJC17QIJd7plsUYhhQ=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085137",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285557",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEQCIAaMxP1zK5i71hMMQzhTsouJUH2LPr6Ip3C+8jnH7iDYAiBCF5O4WsKVFoFqVi4SpRpviSsycfW90lKQ3c+GEpebog=="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180875",
+                            "rootHash": "w1NiUdsbDKJS0phpEzyktHSyssfCyZmRWfzr1v6Arlk=",
+                            "treeSize": "98180876",
+                            "hashes": [
+                                "jdZujlcndhTiJVlzSKNm6KYIfL69zUA8/PHUANwr5Js=",
+                                "VPDhG+wckci72R55DmzOEnahSHNUBYJ3vk81XcUi+xM=",
+                                "vvhDO7GzdG0ioNdbR9gtYfEdjf4ULPbO0j8vs99i4mw=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180876\nw1NiUdsbDKJS0phpEzyktHSyssfCyZmRWfzr1v6Arlk=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiAh7FsYuvGZWoozHNUIuxM123oLv/rXI80x79z4JaTJVQIhAMu95hplC9dY8vy11S3wzOw7FmpMdWZmKhq9LMZuqxxq\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIyNzliMWQwZTJiMWI2Y2VjZTZmMDNlNDkyMThhYWNjY2ZkMTAzNjdlMDdiNzg1ZWRlYjFkNDEzNTUwNzQzNGMxIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURkcHRQbHFZdlIrUjB3RXhvcWlSTEZTTENvR21MaGNQOHplUFF1Y3BvR0NRSWhBSkRLQkNjeFNNODg5ZkhRc29kUjg4Sjh2TXF2MXlMaXo1cW8yREJ4ajA4RCIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4UFowRjNTVUpCWjBsVlJWb3hUWEZHY0ZkdmFWTmtRbEk1U2paTlVqTk5OM2RGZFhsQmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BOTWxkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWsweVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZRY0d4SFlXTlpjVlIzY1U0ck5VZG5TVU5TVmtNMlVYaEdjV1Z4TjBSalUyMTJkVVFLY0doWWFFUlRObVpKWjNac2VrRk5aV2xhYkdkTWR5dGxWbHBMVkV4U1dHcENNbk5YWTJzclFYWTRkU3N2YjBaWU1UWlBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZLSzA5Q0NrdEpMMlZqTWtKNlNGRlRSRXRYUlVWeGQwSjFjMUZCZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zYURWSlFRcEJRVkZFUVVWWmQxSkJTV2RCVjNOdkwyVnVjazE1U205T2FFUk1iRUoyUkVjelNYZEVVMUZpZVM5b00wRnBOWEpsYVdaMlFXMW5RMGxDYWpVdlpVZHdDak5FY214UmIwSnVkVWxCT1Rrdk4xTk9SRmsxTUcxRlUyRlVaVmh3VERWVWRuTk5NazFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbWRCVFVkVlEwMVJSRVVLV2xsMGJuWjRLMVZhTjA1WE0xTXJXRFE0UVVGVmEyNXVlR1p2UVVoRmFsbDVWV2h5YUZGeVFUbHFhV04yVDFSbWRFNHliakpWVldGNGFWUnVNelJaUXdwTlFVVjJkVlEwYnpGRFNuRlFOMnhOVWxkeFIwWmpSRU42TlVSd2JrVkVNbFo2SzBJeVkxbHRhbEo1ZW1OeGFUVmxTa014TjFGSlNtUTNjR3h6VlZsb0NtaFJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "J5sdDisbbOzm8D5JIYqszP0QNn4Ht4Xt6x1BNVB0NME="
+                },
+                "signature": "MEYCIQDdptPlqYvR+R0wExoqiRLFSLCoGmLhcP8zePQucpoGCQIhAJDKBCcxSM889fHQsodR88J8vMqv1yLiz5qo2DBxj08D"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2.exe",
+        "sha256": "46fa2a9e42af39ab5d2ab06e85a5c3a3e652afcc96be415d756fe3e83d05e07b",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2.exe",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "09f328697c9eec1d946950bdfa816ae3",
+            "File Size": "27.0\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlOgAwIBAgIUN7xhdsvRxhIyj11ZXV0KCN7sK2gwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjQwWhcNMjUwNTI2MTkwMjQwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQzLBLkFN+4OP+7ZGVn0lVbDdHXbBgv9aezji8aJCvYpLjUgtzgCNkTWkeDCHbCz540+61ABmszWGNVF8nyS1CaOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUdUCpu0zrhnAB8PwW10BKMAJgFF8wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wlfoAAAQDAEYwRAIgf8nfHAm3ndRiFSfZfi6sccbQC4rP/KJ2LFKz802mfSkCIHTIedUOza+trFd302a8/fn13+jWYy785Z+bmRLvZG3jMAoGCCqGSM49BAMDA2kAMGYCMQD83FE41kkxmqe/wTIVPSJ5p8TPW0ECaHGBpyxl5Rf3sqTkLVCmVghWHB8SVb6EicECMQCqa6NsWKzMHeP/LiF+q7KS1QG7XFlewVzyYB+/FrImIvsRjsvtaWHp8qCLcOqiY/o="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085149",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285560",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQC/32VvSFsDZmeR1180h2hjY7bdZ8jAMw8+nx/Mx4iJNAIgJN2QqgicVOqCws+8vzYAbses+RDnlDbagx9qCxzxKjE="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180887",
+                            "rootHash": "xSJclZtddt5PprDdYYSKVNz0x3v6Ru6EGZxvWW0wuGQ=",
+                            "treeSize": "98180888",
+                            "hashes": [
+                                "I1BxEBkksOtzn+LGJFPJEXJwZWo/fE3ez9RDsR0HHKw=",
+                                "MzWPHJ/Nitd2qrzm5zB0ltT41WoGlphjM88a3M/VrF0=",
+                                "9k5+tY2DFAGrHQ6583Kh6WTjsBKvggOCLNbugaWh7lk=",
+                                "cl4Fbo4wB4YQz3beedRg8C7iXEHrxUZi+wUHQBBaq48=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180888\nxSJclZtddt5PprDdYYSKVNz0x3v6Ru6EGZxvWW0wuGQ=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiBmYI1bN8PajD3Oe0GOtMIZ+6MFVwtqyJKuihdhruutwAIhAIZQYDYlulraytD4MKU7y1Ftxkq5zgjmBkf7UaBQs8nu\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI0NmZhMmE5ZTQyYWYzOWFiNWQyYWIwNmU4NWE1YzNhM2U2NTJhZmNjOTZiZTQxNWQ3NTZmZTNlODNkMDVlMDdiIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJRzh1OEhzNFBYM3YrZVowU3Uvc3E2MkcrSnZQT2tlbk1TckFGWUhBUmtmTkFpQUNoWFpCL09uSUp1bkFVV2Vvd0hZYTRmU1VRaXhSbUxQek1QNlg1aUVhaXc9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4UFowRjNTVUpCWjBsVlRqZDRhR1J6ZGxKNGFFbDVhakV4V2xoV01FdERUamR6U3pKbmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BSZDFkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxGM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZSZWt4Q1RHdEdUaXMwVDFBck4xcEhWbTR3YkZaaVJHUklXR0pDWjNZNVlXVjZhbWtLT0dGS1EzWlpjRXhxVldkMGVtZERUbXRVVjJ0bFJFTklZa042TlRRd0t6WXhRVUp0YzNwWFIwNVdSamh1ZVZNeFEyRlBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZrVlVOd0NuVXdlbkpvYmtGQ09GQjNWekV3UWt0TlFVcG5Sa1k0ZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zYkdadlFRcEJRVkZFUVVWWmQxSkJTV2RtT0c1bVNFRnRNMjVrVW1sR1UyWmFabWsyYzJOallsRkROSEpRTDB0S01reEdTM280TURKdFpsTnJRMGxJVkVsbFpGVlBDbnBoSzNSeVJtUXpNREpoT0M5bWJqRXpLMnBYV1hrM09EVmFLMkp0VWt4MldrY3phazFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbXRCVFVkWlEwMVJSRGdLTTBaRk5ERnJhM2h0Y1dVdmQxUkpWbEJUU2pWd09GUlFWekJGUTJGSVIwSndlWGhzTlZKbU0zTnhWR3RNVmtOdFZtZG9WMGhDT0ZOV1lqWkZhV05GUXdwTlVVTnhZVFpPYzFkTGVrMUlaVkF2VEdsR0szRTNTMU14VVVjM1dFWnNaWGRXZW5sWlFpc3ZSbkpKYlVsMmMxSnFjM1owWVZkSWNEaHhRMHhqVDNGcENsa3ZiejBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "RvoqnkKvOatdKrBuhaXDo+ZSr8yWvkFddW/j6D0F4Hs="
+                },
+                "signature": "MEQCIG8u8Hs4PX3v+eZ0Su/sq62G+JvPOkenMSrAFYHARkfNAiAChXZB/OnIJunAUWeowHYa4fSUQixRmLPzMP6X5iEaiw=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-arm64.exe",
+        "sha256": "8eefd4d9c7985fbe9ec36466c0453211493e9ccdf8f5eef83524101be0fac9d8",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-arm64.exe",
+            "Operating System": "Windows",
+            "Description": "Experimental",
+            "MD5 Sum": "60bb4e7f7df999dcaef36f4b46e2a180",
+            "File Size": "27.7\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-arm64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-arm64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlOgAwIBAgIUUbVlK6yq7EZyh+SAH5I/dm9tSvwwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjQ4WhcNMjUwNTI2MTkwMjQ4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXoejxVDCdHI+pJCfH0LdDooRgdUcpIzO7nV4m2JLPBvPrqwZqLaTvejqQ26kxTyBiH2zO13xGKz0NW27pbx4n6OCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUhK4+Is74xGxlS+RCKepxYFMAZ7AwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wt4EAAAQDAEYwRAIgWx7D3cvwKKIujeF4wMdRqFhyTw1APpVnW3cIKtK1Z1MCIHhdQoLv7TTZdLKFn1DC7aQaEXMJA4viskQHJdrNTu00MAoGCCqGSM49BAMDA2cAMGQCMHyu+WCXLUyOlQZ5EZMOJgnY8W6FihcZqyjEJK04wAs3+CFanyBwrbUgT6880KX5tQIwB7t8K/liDNcFnYieJrk0m6Dsi8WOgmR9VtG+6YzxYFsA5iZvLjo6bQEp0CVcxBNl"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085179",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285569",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQCFlXxolL+XQQC3uYR55r/7yQT65RRNB7kgN2RHS6zpqwIgECel0o8U2OwvaTFX4u4B3jfu8jb3OYjfn8zvZ+jP8IM="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180917",
+                            "rootHash": "7RjvouJ3kEtuusBtrZ//zhogH1tjuB3MoFpL+jSJeOU=",
+                            "treeSize": "98180919",
+                            "hashes": [
+                                "/50I7ioc8QI3gdKTWhy/gTCrhIsaioj7W5xGZ90ejMM=",
+                                "SISnrIOWRXVSmILXh2sBkr5pl+RD3yQz5cBYgn05pSM=",
+                                "cWs8MgQ42nX1zsesgN3ZVsMvGroyS4+qwx4x4uZ6Hnk=",
+                                "oDFYFMRSOkkV8vM6GSo7AoHHtzfKi8UZPq/rKvNTcRg=",
+                                "3pI6V71WkxutIHjM0WkuBRhQdfcH4rIgtz/Eg3NETUo=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180919\n7RjvouJ3kEtuusBtrZ//zhogH1tjuB3MoFpL+jSJeOU=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAheRy6zJdaiANbwB3Pxs49bZQcvmVBXHg+HBlMY1Oq04CIQC4d32L49Vt8K2PrzCoJtUMuV6cMPioexDB7lng6uL/AQ==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI4ZWVmZDRkOWM3OTg1ZmJlOWVjMzY0NjZjMDQ1MzIxMTQ5M2U5Y2NkZjhmNWVlZjgzNTI0MTAxYmUwZmFjOWQ4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJQ0gxa2MxemhWeUpscXptd1E1bTg0aFhPNlZEWnFUTHJiNi92ajFQTnRKdEFpRUFsNHJCOEtBYjBab1VKSXJJOTU1WlhIRzRXVmJQM2ZKYTAzZnFUTzdlYklrPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4UFowRjNTVUpCWjBsVlZXSldiRXMyZVhFM1JWcDVhQ3RUUVVnMVNTOWtiVGwwVTNaM2QwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BSTkZkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxFMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZZYjJWcWVGWkVRMlJJU1N0d1NrTm1TREJNWkVSdmIxSm5aRlZqY0VsNlR6ZHVWalFLYlRKS1RGQkNkbEJ5Y1hkYWNVeGhWSFpsYW5GUk1qWnJlRlI1UW1sSU1ucFBNVE40UjB0Nk1FNVhNamR3WW5nMGJqWlBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZvU3pRckNrbHpOelI0UjNoc1V5dFNRMHRsY0hoWlJrMUJXamRCZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zZERSRlFRcEJRVkZFUVVWWmQxSkJTV2RYZURkRU0yTjJkMHRMU1hWcVpVWTBkMDFrVW5GR2FIbFVkekZCVUhCV2JsY3pZMGxMZEVzeFdqRk5RMGxJYUdSUmIweDJDamRVVkZwa1RFdEdiakZFUXpkaFVXRkZXRTFLUVRSMmFYTnJVVWhLWkhKT1ZIVXdNRTFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbU5CVFVkUlEwMUllWFVLSzFkRFdFeFZlVTlzVVZvMVJWcE5UMHBuYmxrNFZ6WkdhV2hqV25GNWFrVktTekEwZDBGek15dERSbUZ1ZVVKM2NtSlZaMVEyT0Rnd1MxZzFkRkZKZHdwQ04zUTRTeTlzYVVST1kwWnVXV2xsU25Kck1HMDJSSE5wT0ZkUFoyMVNPVlowUnlzMldYcDRXVVp6UVRWcFduWk1hbTgyWWxGRmNEQkRWbU40UWs1c0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "ju/U2ceYX76ew2RmwEUyEUk+nM349e74NSQQG+D6ydg="
+                },
+                "signature": "MEUCICH1kc1zhVyJlqzmwQ5m84hXO6VDZqTLrb6/vj1PNtJtAiEAl4rB8KAb0ZoUJIrI955ZXHG4WVbP3fJa03fqTO7ebIk="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-amd64.zip",
+        "sha256": "05293debfd2d5e0face60f6646d50b4985806f70fba573341709a6eebf5dcf98",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-amd64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "353c6437551776994f51c0fe3b7d4e45",
+            "File Size": "11.4\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-amd64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-amd64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzTCCAlSgAwIBAgIUU/K2t6OqANR7cOdejhDcjg1XZFMwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjQ1WhcNMjUwNTI2MTkwMjQ1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdcaiR54LuOuCVq/a5nQDaDmw1DmT+mVEyNoVXJ1s83Ku4nKWXGYgZJ1gWcBPtUGSk7ugx1C3eBZP3WrpAe4ZF6OCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUoWovm7r4q6LdLcGCsO98UCD4M1YwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wqXkAAAQDAEcwRQIgGU1xYFhB8g6x2DGhsfOTLwbAIjCipRnwEqDFK6OufFsCIQDYPDvmP4X8o9B2ef1LpBEPwNlWvF0ZpDkPoVH+jY8tHzAKBggqhkjOPQQDAwNnADBkAjA0EBjKgCxko+nmeaa3BxIJyUVxJRkBcQi5R+NjCDaP2ifq4Xym512Q61aVawvgtLICMAL1FbFcXSSlC/jnHPv3p+O2XV73E+tzLHG1UUYq+rl4wUP1hyS1qrB6gSRmklS9OA=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085163",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285565",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIEawPB0OTzasdSGjxhsMxZZwXickrhmfS+v5FFB3Jm/8AiEAnqRo0BHVIiDHumhQFvy3HDtQS4KJAT9j6UuSh7ab0IQ="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180901",
+                            "rootHash": "XE9+rCia7EPHJ3zvgltI2ejc578oKB2qhnlgtR5ndWY=",
+                            "treeSize": "98180902",
+                            "hashes": [
+                                "HchVqeqFoaJSdHwbrMsA1tU6qoqt9hSXvzq3+iiUesI=",
+                                "r3zUTxwuN+JjZ/Vj1ejtqNYXvbn2TiIZCtKVMiCQuPI=",
+                                "3pI6V71WkxutIHjM0WkuBRhQdfcH4rIgtz/Eg3NETUo=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180902\nXE9+rCia7EPHJ3zvgltI2ejc578oKB2qhnlgtR5ndWY=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiA4LWSasfPMs/QpIyox0fVkzAj7UciVL8enoppsU6LkLAIgBnZ53EavQl10u9AbiFdppOTLVH+BnoXlILve9kLNUYQ=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIwNTI5M2RlYmZkMmQ1ZTBmYWNlNjBmNjY0NmQ1MGI0OTg1ODA2ZjcwZmJhNTczMzQxNzA5YTZlZWJmNWRjZjk4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURrU1lyTG1RdVJxWGhHMjhYOWFGUmtaL3JPU3IxKzZGZHV1VG1ieUN6OHhRSWhBS2w1cVVYa05ISnpuWlFVbzVWR1RYdklyeUNVWGZyVDlXYm1QOTVLR0VhdiIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4VFowRjNTVUpCWjBsVlZTOUxNblEyVDNGQlRsSTNZMDlrWldwb1JHTnFaekZZV2taTmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BSTVZkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxFeFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZrWTJGcFVqVTBUSFZQZFVOV2NTOWhOVzVSUkdGRWJYY3hSRzFVSzIxV1JYbE9iMVlLV0VveGN6Z3pTM1UwYmt0WFdFZFpaMXBLTVdkWFkwSlFkRlZIVTJzM2RXZDRNVU16WlVKYVVETlhjbkJCWlRSYVJqWlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ2VjI5MkNtMDNjalJ4Tmt4a1RHTkhRM05QT1RoVlEwUTBUVEZaZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zY1ZoclFRcEJRVkZFUVVWamQxSlJTV2RIVlRGNFdVWm9RamhuTm5neVJFZG9jMlpQVkV4M1lrRkpha05wY0ZKdWQwVnhSRVpMTms5MVprWnpRMGxSUkZsUVJIWnRDbEEwV0Rodk9VSXlaV1l4VEhCQ1JWQjNUbXhYZGtZd1duQkVhMUJ2VmtncmFsazRkRWg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV1UVVSQ2EwRnFRVEFLUlVKcVMyZERlR3R2SzI1dFpXRmhNMEo0U1VwNVZWWjRTbEpyUW1OUmFUVlNLMDVxUTBSaFVESnBabkUwV0hsdE5URXlVVFl4WVZaaGQzWm5kRXhKUXdwTlFVd3hSbUpHWTFoVFUyeERMMnB1U0ZCMk0zQXJUekpZVmpjelJTdDBla3hJUnpGVlZWbHhLM0pzTkhkVlVERm9lVk14Y1hKQ05tZFRVbTFyYkZNNUNrOUJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "BSk96/0tXg+s5g9mRtULSYWAb3D7pXM0Fwmm7r9dz5g="
+                },
+                "signature": "MEYCIQDkSYrLmQuRqXhG28X9aFRkZ/rOSr1+6FduuTmbyCz8xQIhAKl5qUXkNHJznZQUo5VGTXvIryCUXfrT9WbmP95KGEav"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-win32.zip",
+        "sha256": "8efc4a76ff09c58cdfbbec1210cd686f78e06c66585e19280618a3c4b74b1ce9",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-win32.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "5c2a1aa6a4f8666d859dc7c895f2cf66",
+            "File Size": "10.0\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-win32.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-win32.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlSgAwIBAgIUJiGTjmobSROa91AiH9SXiBHOM3QwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjUwWhcNMjUwNTI2MTkwMjUwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3ynqYk9PsQoSzcQNLURVLB4II459ojLiSRXXUoRm4ikIVpL6YwoAaBQI1sn9pglZOa9/OxbUE7QYbi4/vu2H6KOCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUhD48+B6vPDiGKFRU0sWaEoEL+LMwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wvrQAAAQDAEcwRQIhAIX6t57mllr40PufEbuyLwB1HxViyMlz32a2DzetLtIwAiBIxBSKaf5DqWPOfxGIcO8Zj8+0rpVq2V7II9OL1pFGcTAKBggqhkjOPQQDAwNoADBlAjAtl0YL8ypuj362MoCbBqkEH0j7OxDGTDRDh4rv3bIjzc5jl96/UfDlcONXmsJ3atsCMQCs1lqMwSyqF6ygBneqhj7iargMgYzj5858XFmJ83bw2payZ9k5WHGYFCARsQ/Lk2A="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085182",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285570",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQDxOvdWNZr5mQ7j6kRa3Bfn5OZpWN9q7DNx5YUvgNZMRgIgTUd1Gm4iB+u0ikoKBBtKGsEUekO63fho2peCjCerEdk="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180920",
+                            "rootHash": "RJMttx7tF355gEBSf9ofcoC26edVjDMdHBsl+h5KYAs=",
+                            "treeSize": "98180921",
+                            "hashes": [
+                                "x7tFWAzK96jydB/JqbCN4Cwc8HVNIsNYwzsXk8id/UE=",
+                                "oDFYFMRSOkkV8vM6GSo7AoHHtzfKi8UZPq/rKvNTcRg=",
+                                "3pI6V71WkxutIHjM0WkuBRhQdfcH4rIgtz/Eg3NETUo=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180921\nRJMttx7tF355gEBSf9ofcoC26edVjDMdHBsl+h5KYAs=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAGOsWSAZCUBreLjKHfvsCome84JAnVkJQmzyP9VAhCBwIgQWlMbkfAE1MvfAUBWf3eptu0j9ES6D6KZnsPxu6Bof0=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI4ZWZjNGE3NmZmMDljNThjZGZiYmVjMTIxMGNkNjg2Zjc4ZTA2YzY2NTg1ZTE5MjgwNjE4YTNjNGI3NGIxY2U5In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUNkUThlL1MzdTZjN1JHaXBkcDBOU1hRcGFoaG1UdFlwdkdpbDR1WjhndUlRSWdWclBaajZxb1ZaUFloaXg4VGllMVU2K2xvYVR0VGwzVWp3ZlIvZE1nOGRFPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVlNtbEhWR3B0YjJKVFVrOWhPVEZCYVVnNVUxaHBRa2hQVFROUmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BWZDFkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxWM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVV6ZVc1eFdXczVVSE5SYjFONlkxRk9URlZTVmt4Q05FbEpORFU1YjJwTWFWTlNXRmdLVlc5U2JUUnBhMGxXY0V3MldYZHZRV0ZDVVVreGMyNDVjR2RzV2s5aE9TOVBlR0pWUlRkUldXSnBOQzkyZFRKSU5rdFBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZvUkRRNENpdENOblpRUkdsSFMwWlNWVEJ6VjJGRmIwVk1LMHhOZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zZG5KUlFRcEJRVkZFUVVWamQxSlJTV2hCU1ZnMmREVTNiV3hzY2pRd1VIVm1SV0oxZVV4M1FqRkllRlpwZVUxc2VqTXlZVEpFZW1WMFRIUkpkMEZwUWtsNFFsTkxDbUZtTlVSeFYxQlBabmhIU1dOUE9GcHFPQ3N3Y25CV2NUSldOMGxKT1U5TU1YQkdSMk5VUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFRWFFLYkRCWlREaDVjSFZxTXpZeVRXOURZa0p4YTBWSU1HbzNUM2hFUjFSRVVrUm9OSEoyTTJKSmFucGpOV3BzT1RZdlZXWkViR05QVGxodGMwb3pZWFJ6UXdwTlVVTnpNV3h4VFhkVGVYRkdObmxuUW01bGNXaHFOMmxoY21kTloxbDZhalU0TlRoWVJtMUtPRE5pZHpKd1lYbGFPV3MxVjBoSFdVWkRRVkp6VVM5TUNtc3lRVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "jvxKdv8JxYzfu+wSEM1ob3jgbGZYXhkoBhijxLdLHOk="
+                },
+                "signature": "MEUCIQCdQ8e/S3u6c7RGipdp0NSXQpahhmTtYpvGil4uZ8guIQIgVrPZj6qoVZPYhix8Tie1U6+loaTtTl3UjwfR/dMg8dE="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-arm64.zip",
+        "sha256": "73b5f87a458bf8d343d3c65df19b2cecb012759d0829920ad8d7d98dcd2e9f57",
+        "release_url": "https://www.python.org/downloads/release/python-3140b2/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-arm64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "e660e23444b77edb8cdb204bbba9e3c8",
+            "File Size": "10.6\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-arm64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b2-embed-arm64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlSgAwIBAgIUNKtsvuSuJ7yNLS1abZziPV3hXN4wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNTI2MTg1MjQxWhcNMjUwNTI2MTkwMjQxWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjyQaIDimRD2elp2Z0fS4nyBy3ICJYaqPHClkxvrQBDJReGsW0AM7UeQvxRDNn5wrW4+RssPDqXwVMuyioAwVDaOCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUssGdoDPENDTrhqxuLj3maLQdp7QwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlw3wnIUAAAQDAEcwRQIhAOBD+CpUSaPAjs7GwG6R5fQv8vQgTJgAIGj5D9XJA+cWAiAM5ADZ8Ms1xBhwdDZT39M2QblF9sBt3RId4aBVnuax2TAKBggqhkjOPQQDAwNoADBlAjAB7eP9w3bCVeZcjVqH3pbqESwXRcdPHClZUJQuzGcY3/O19C+X9TD2UAp0SPjFTG8CMQCVDN5NU/gAr+He/KcFp6Ilk34F9Nnkj3PzKWj+KeFp/iCfHHMJ0a4a1GMEh3xQd7U="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "220085154",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748285562",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQCXIxhpPGmwGZi/2Y5jcM2gsGdGaELAlnWwqiURR+Y9XQIhAJeItz8Il+JRynrExuxz2eMFul2iiV231tBf/kdD+MlL"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "98180892",
+                            "rootHash": "zG1rs4Z+VX2637e2/Vixyf9qWWNw4R1UjcosNfr9k3g=",
+                            "treeSize": "98180893",
+                            "hashes": [
+                                "CGAzjKNWr1QnWzQ9JFDBKho71tNXHyTw/Z30CY16Ef8=",
+                                "ZxnI7UUuzluqUZ+jQDsQags7dlmGhiyI40REFnRaAhk=",
+                                "cl4Fbo4wB4YQz3beedRg8C7iXEHrxUZi+wUHQBBaq48=",
+                                "VO/ynlJFyNcbFD02zmJvM2Mm5UzEqpS9xgM8dZx4JF0=",
+                                "r2VV9zsLHKN1LyQmhqsyIMIF3MZsuxC3Geh/oidHzjk=",
+                                "qFks5wqXYAN2/6NiWw9BmDqOK85OYWocXHq2CabxWUg=",
+                                "1CSYp0Uxm7lUrq9j7DuYJ9ShY9P8tJVIf9mb9ubOsBs=",
+                                "lCWSLVZukVJwp1i7tSNta774H8uCYwvFZoiU+IG48HA=",
+                                "TN3oG+6KnCkr9fBEaBUHHyghBPa5AYM2QmDIhyd7PP8=",
+                                "yeJj3pYQkMFCH/OfTlCSZvGxI+sDQOuuH20/lxLt7gs=",
+                                "tp5gt2QgBd2gmRM5Vhz5vhEC//9CyS41WCVQRpJm/dk=",
+                                "+jKVBl9RI6O7U6XYJ+AwciNKMCW+hkgk3R4JtuB+FJA=",
+                                "h5VTNNCORtYrwvf9h5wlAx+k3+9SY5/VIETuNnly6Xk=",
+                                "++1LMuz3tIdW1/pfEfhPfXC4ot1AwDAXDcPyfibzGyc=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n98180893\nzG1rs4Z+VX2637e2/Vixyf9qWWNw4R1UjcosNfr9k3g=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAb9k/QdojvzhUX9DLbKGkZm2qqYuzs+YLtVQil0zkczQIgbdXjWaYs/4Xv99y1j1WrS9BvcxV1eZHvpZtOPGCx7qE=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3M2I1Zjg3YTQ1OGJmOGQzNDNkM2M2NWRmMTliMmNlY2IwMTI3NTlkMDgyOTkyMGFkOGQ3ZDk4ZGNkMmU5ZjU3In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUM3QzA1VWozaGJwYUJzM3VlSS9XdHNDQk1raUhIcnhYb3EwWnIyU2t5alhRSWdJZ2Y0RW1DNTQ4NkhrZGZIdEhtdS8yUDlGTmsyK3ZQd2R1ZjB5eDhpbFhVPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVlRrdDBjM1oxVTNWS04zbE9URk14WVdKYWVtbFFWak5vV0U0MGQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVVU1RKTlZHY3hUV3BSZUZkb1kwNU5hbFYzVGxSSk1rMVVhM2ROYWxGNFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZxZVZGaFNVUnBiVkpFTW1Wc2NESmFNR1pUTkc1NVFua3pTVU5LV1dGeFVFaERiR3NLZUhaeVVVSkVTbEpsUjNOWE1FRk5OMVZsVVhaNFVrUk9ialYzY2xjMEsxSnpjMUJFY1ZoM1ZrMTFlV2x2UVhkV1JHRlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ6YzBka0NtOUVVRVZPUkZSeWFIRjRkVXhxTTIxaFRGRmtjRGRSZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNkek4zYmtsVlFRcEJRVkZFUVVWamQxSlJTV2hCVDBKRUswTndWVk5oVUVGcWN6ZEhkMGMyVWpWbVVYWTRkbEZuVkVwblFVbEhhalZFT1ZoS1FTdGpWMEZwUVUwMVFVUmFDamhOY3pGNFFtaDNaRVJhVkRNNVRUSlJZbXhHT1hOQ2RETlNTV1EwWVVKV2JuVmhlREpVUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFRVUlLTjJWUU9YY3pZa05XWlZwamFsWnhTRE53WW5GRlUzZFlVbU5rVUVoRGJGcFZTbEYxZWtkaldUTXZUekU1UXl0WU9WUkVNbFZCY0RCVFVHcEdWRWM0UXdwTlVVTldSRTQxVGxVdlowRnlLMGhsTDB0alJuQTJTV3hyTXpSR09VNXVhMm96VUhwTFYyb3JTMlZHY0M5cFEyWklTRTFLTUdFMFlURkhUVVZvTTNoUkNtUTNWVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "c7X4ekWL+NND08Zd8Zss7LASdZ0IKZIK2NfZjc0un1c="
+                },
+                "signature": "MEUCIQC7C05Uj3hbpaBs3ueI/WtsCBMkiHHrxXoq0Zr2SkyjXQIgIgf4EmC5486HkdfHtHmu/2P9FNk2+vPwduf0yx8ilXU="
+            }
+        }
+    }
+]

--- a/versions/3.14.0b3.json
+++ b/versions/3.14.0b3.json
@@ -1,0 +1,674 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tgz",
+        "sha256": "ac25adf76484728527fb621bc14a83c1ddd43f9a7a0a7fdbb07d09722fec5f3d",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "91fdd2af3f464cd5e8832145bed75c0d",
+            "File Size": "29.2\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tgz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tgz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzTCCAlOgAwIBAgIUfE+ns5I1Z2u3xGU1RiL4WvkMPBMwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjMwWhcNMjUwNjE3MTg0MjMwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfuyzzct1v/rmh84CdKeqDyPH2YFinyUxpmaPFtvz0tlwclVmOtkZWW9QC1kInNdoeEgBdPzkn9uG7fkttQg5A6OCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU24mgumZsjecsL0IkzZL81sUG73IwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38qCFAAAAQDAEYwRAIgZXvCSwKliJ7ButRskdnx2Fa++aXpje6mDCBhH2jqs+MCIDJ/3t5X3EkP4sgI/xTV149WtTPeZ9q9VUhKiyD0kCsAMAoGCCqGSM49BAMDA2gAMGUCMQDFUk87Z9nOwTc7Pr5x+WA1kK5Db88+ERzqNBpU27tYIPS9XVBibdknK9NJ1wNdooMCMGI4QdQ57InnLGC5sycwh/rQcoZZ2fsJZGjnA3FXNqIBs8Nu2r+5f3Kf6Ybc8f4OaQ=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091472",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185150",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIDONheXm0LdOCmpJeQTNZdoL74yVluLthtQrW4O770qYAiEAvE7cFNmdL6h3PyjDjoONRPl/p0zAkLL9FXZUtUADW6w="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120187210",
+                            "rootHash": "ceAnFDwiD8XHo3sALL4AM3WTepEHzgtak01sQJNhPmw=",
+                            "treeSize": "120187223",
+                            "hashes": [
+                                "308jtQ/VpSGfxTQiabsLZ6sykybCNEV3JaqDOMIZnyM=",
+                                "dFqjcwSaBW4QQFVsyo22PRfylXgyW6/yQ0teyTYgMXQ=",
+                                "ENgM58uSAbkOScXIN2VrDo/c836gmAtp3p5wrHMhi3c=",
+                                "lLLr24XoNx72SD+zaJVbIVzLFrRZPQKaYd3wbY6p/MM=",
+                                "xRkGth9/3ufntIOMOI8k6DLjDlNwZdniPCGtR7nvWxE=",
+                                "9k1Bdhrxl01hghuYrVZlJfSYrDVTuneisaBU4ZdzgTM=",
+                                "Dzdf3VUntY5OjGUWVOdNuSvBOlT3oFQ9cEB5XuBItyQ=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120187223\nceAnFDwiD8XHo3sALL4AM3WTepEHzgtak01sQJNhPmw=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEAoj5HyeHoo6GvUByM5ZNi/2BnoOfFdllJtIVbH5HWbCcCIBrOqq3BbYB5UN2n2F0LL1qmS6LOnKplV0jQvzMQRNw7\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJhYzI1YWRmNzY0ODQ3Mjg1MjdmYjYyMWJjMTRhODNjMWRkZDQzZjlhN2EwYTdmZGJiMDdkMDk3MjJmZWM1ZjNkIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUQ1TzhXRnVLdUE4RXdWSTNMQ0J4dCtVOVVYaUZvaUhnQWVLL1prSEJySmNRSWdUMXFYMmszMTUzbFJkTWp3OVVIMlJCMkRQWktweWlNNSt0N01iT2JyUFg4PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4UFowRjNTVUpCWjBsVlprVXJibk0xU1RGYU1uVXplRWRWTVZKcFREUlhkbXROVUVKTmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BOZDFkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWsxM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZtZFhsNmVtTjBNWFl2Y20xb09EUkRaRXRsY1VSNVVFZ3lXVVpwYm5sVmVIQnRZVkFLUm5SMmVqQjBiSGRqYkZadFQzUnJXbGRYT1ZGRE1XdEpiazVrYjJWRlowSmtVSHByYmpsMVJ6ZG1hM1IwVVdjMVFUWlBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlV5TkcxbkNuVnRXbk5xWldOelREQkphM3BhVERneGMxVkhOek5KZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh4UTBaQlFRcEJRVkZFUVVWWmQxSkJTV2RhV0haRFUzZExiR2xLTjBKMWRGSnphMlJ1ZURKR1lTc3JZVmh3YW1VMmJVUkRRbWhJTW1weGN5dE5RMGxFU2k4emREVllDak5GYTFBMGMyZEpMM2hVVmpFME9WZDBWRkJsV2pseE9WWlZhRXRwZVVRd2EwTnpRVTFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbWRCVFVkVlEwMVJSRVlLVldzNE4xbzViazkzVkdNM1VISTFlQ3RYUVRGclN6VkVZamc0SzBWU2VuRk9RbkJWTWpkMFdVbFFVemxZVmtKcFltUnJia3M1VGtveGQwNWtiMjlOUXdwTlIwazBVV1JSTlRkSmJtNU1SME0xYzNsamQyZ3ZjbEZqYjFwYU1tWnpTbHBIYW01Qk0wWllUbkZKUW5NNFRuVXljaXMxWmpOTFpqWlpZbU00WmpSUENtRlJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "rCWt92SEcoUn+2IbwUqDwd3UP5p6Cn/bsH0Jci/sXz0="
+                },
+                "signature": "MEUCIQD5O8WFuKuA8EwVI3LCBxt+U9UXiFoiHgAeK/ZkHBrJcQIgT1qX2k3153lRdMjw9UH2RB2DPZKpyiM5+t7MbObrPX8="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tar.xz",
+        "sha256": "c6f48bf51f01f50d87007a445dd7afe4a4c7a87ab482570be924c1ddfd0d3682",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "fe1c20dca37feeb82060788d6df42c9d",
+            "File Size": "22.5\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tar.xz.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b3.tar.xz.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzzCCAlWgAwIBAgIUByJGQuqs91nWmaSz3zDw8u9QrXkwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjM0WhcNMjUwNjE3MTg0MjM0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQKkvjy/DW6XBsNL4KGhn7Cbq002FEsNX5ib1Iwi1WbfolR8yyD2I0olxG7HmG3bcB7ULI6b41QEgUJNoBG18c6OCAXQwggFwMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUE5DKgIP1/0qYhsOJ2K9A0QLz34EwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38qFpEAAAQDAEgwRgIhAPrfzRQy69XLVERM/SGXe90jKTPdKG+8RCDk3lbQDNsiAiEAwhy9MnhJ3/rTJ3kdFjLNj/1vAf0Svp6LEizf9ZmvbCowCgYIKoZIzj0EAwMDaAAwZQIxAOF+hxPqGCi20YU2FgjlzNc1GzsfasUIUZA4+BUd7sbALI8h6p/bm3EzLCerAawdggIwCLSzarb3Pn0LZrZln9a7Vagbme5MoUQ35VU8yDn10p9ayGwXhHiLgzxxkWU4p14z"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091651",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185154",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIEgCIEakIe/cVyoSmGmQGH5sRE+ZAKq+bSXjJR3mBB+2AiEAolJax6DoqlLLSMOqeu3qSJvPtx2DtgAm1V6SQvniZ9c="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120187389",
+                            "rootHash": "CBZhzRNuYSMIkvqy0+VtKfvWaRrldFCQvLROqwpICJ8=",
+                            "treeSize": "120187397",
+                            "hashes": [
+                                "ZoSBJN7hwnnK+AwaHbj98vodiu0iqsh8l0KBMKa6fnE=",
+                                "nwvLeMO7z+S2qyu4wfIQPFR7FPMSZlXwZPCnHFWjh+w=",
+                                "CO8xe1g5Ldm4l5MUcIn2pmfgifnYfWiE41S9AhluDaA=",
+                                "fwnnvZ/rcmNlH9G74uFshxfK5qeuy4q0w03ecv2A7s8=",
+                                "lAzaEU6k8f/W3+t/uhgSqMI78Xb2k9p3SZNxTnIGGNU=",
+                                "S/H7ELYDVa/9BZtfi8TmhZSXqQhQlHE2lP7c0FTbzUg=",
+                                "c2ZZea0xgwt/gVtpXsIKw6/dMmhBHf2QE4+cGR8Hzxc=",
+                                "R1FyFnqsxFAatxvySZLbafflRRbv9Oe5FUwRs70eJTA=",
+                                "Dzdf3VUntY5OjGUWVOdNuSvBOlT3oFQ9cEB5XuBItyQ=",
+                                "6iXN20rIe5WDiGSbP978s/x+mrYskcF/co21+gqmcrE=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120187397\nCBZhzRNuYSMIkvqy0+VtKfvWaRrldFCQvLROqwpICJ8=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEAoo5Vm+/1ZUilU42jf+ObfVMSQO5Rll721LfKDwUuyCYCIG8vPw6Z1iAzXj/pNZZjx0pfdfdiLyOJJ9aTWWJE7uIz\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJjNmY0OGJmNTFmMDFmNTBkODcwMDdhNDQ1ZGQ3YWZlNGE0YzdhODdhYjQ4MjU3MGJlOTI0YzFkZGZkMGQzNjgyIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURSVDVjSHBmK21XNHlXUXRtMXluU1hpQzN2bWZjcXlPYWI5S1hpcmVGYVV3SWhBSTBqY1pkczRLUUxVeE4rWGpTcEMxaVhXRDVCRkNvV0JSbGUwNmt5Qk4zWSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZla05EUVd4WFowRjNTVUpCWjBsVlFubEtSMUYxY1hNNU1XNVhiV0ZUZWpONlJIYzRkVGxSY2xocmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BOTUZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWswd1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZSUzJ0MmFua3ZSRmMyV0VKelRrdzBTMGRvYmpkRFluRXdNREpHUlhOT1dEVnBZakVLU1hkcE1WZGlabTlzVWpoNWVVUXlTVEJ2YkhoSE4waHRSek5pWTBJM1ZVeEpObUkwTVZGRloxVktUbTlDUnpFNFl6WlBRMEZZVVhkblowWjNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZGTlVSTENtZEpVREV2TUhGWmFITlBTakpMT1VFd1VVeDZNelJGZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVhkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWprS1FraHpRV1ZSUWpOQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh4Um5CRlFRcEJRVkZFUVVWbmQxSm5TV2hCVUhKbWVsSlJlVFk1V0V4V1JWSk5MMU5IV0dVNU1HcExWRkJrUzBjck9GSkRSR3N6YkdKUlJFNXphVUZwUlVGM2FIazVDazF1YUVvekwzSlVTak5yWkVacVRFNXFMekYyUVdZd1UzWndOa3hGYVhwbU9WcHRkbUpEYjNkRFoxbEpTMjlhU1hwcU1FVkJkMDFFWVVGQmQxcFJTWGdLUVU5R0syaDRVSEZIUTJreU1GbFZNa1puYW14NlRtTXhSM3B6Wm1GelZVbFZXa0UwSzBKVlpEZHpZa0ZNU1Rob05uQXZZbTB6UlhwTVEyVnlRV0YzWkFwblowbDNRMHhUZW1GeVlqTlFiakJNV25KYWJHNDVZVGRXWVdkaWJXVTFUVzlWVVRNMVZsVTRlVVJ1TVRCd09XRjVSM2RZYUVocFRHZDZlSGhyVjFVMENuQXhOSG9LTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "xvSL9R8B9Q2HAHpEXdev5KTHqHq0glcL6STB3f0NNoI="
+                },
+                "signature": "MEYCIQDRT5cHpf+mW4yWQtm1ynSXiC3vmfcqyOab9KXireFaUwIhAI0jcZds4KQLUxN+XjSpC1iXWD5BFCoWBRle06kyBN3Y"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-macos11.pkg",
+        "sha256": "48532a33882a71440bec08344f92f32dee4b9aab19d50898fc23169ce3757480",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-macos11.pkg",
+            "Operating System": "macOS",
+            "Description": "for macOS 10.13 and later",
+            "MD5 Sum": "0e7f920257cd2d521523e08e31337af1",
+            "File Size": "71.1\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-macos11.pkg.sigstore",
+            "SBOM": null
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlSgAwIBAgIUDPz3aRnhJu6gVF9YyJFBrwGB4QYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjMyWhcNMjUwNjE3MTg0MjMyWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtmEcCXavlwK0gEtuv9cWsifcKc8AdFF15jZ1ynkRUe4wEhtYkL3uhOE7Kj7UVzVw2xA+SR4HpAQUvVB/FcDglqOCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUuHmnCwk1nQ+qlNN0qcUYJwQILNgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38qDyIAAAQDAEcwRQIgOo9YDUcof+RSs/hOOLRZw2Lk+Ni0Bb7t+srMaU6wFhoCIQCZwMWHG0P0k5OwbWLx+FnDlx9ldtHCgL6LyeBJXoACbTAKBggqhkjOPQQDAwNoADBlAjATLVlTSgTfWwiRfE8Toxqhf+7o3qJE7qDJiK2nrBcf3wiaugxv7OegpIDMJD7ncEwCMQCBFeDHIQrGPKJqYnsAi5czYrYHu5lU7AZDkQM8VuPaqhlLHOYdfAVh+oJufEJBgPA="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091577",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185152",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQD641hzL5B4mScc3nTDw3nAVXs87uCIAZ3Aa/Dnb8D1pwIgR9Vbt2MI09i//f3oji80ePu9svxHw2UHs8cWzuVS4YQ="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120187315",
+                            "rootHash": "69N5q2yGYVDIQeyUZvtDdZeI/hbUG/ANy2PWUR30Ss0=",
+                            "treeSize": "120187324",
+                            "hashes": [
+                                "kZxIwnBU8AdgNnObydbs0VUp3Nl36VRjI/BYwoK7bb4=",
+                                "KYoDe1BZfGxXki4luutsWPfQBBpqvlOKY21Oiq8tZsE=",
+                                "tMnZssnDqJjL+AaTMzCjonMfsz37xg8o6md4u0IKrZE=",
+                                "ripS13PMq2L7QG7Ovy1psY2N5SsQJUsU1wQ+0Hz24gw=",
+                                "Qfa/ZvWb/B45iJdsKZx9UbejmyPqhqNApMaICmk8+Sw=",
+                                "XnaZAY1//DQdkWcZ0eLq8llrGHvxEgEHK78y4zsz5Sw=",
+                                "R1FyFnqsxFAatxvySZLbafflRRbv9Oe5FUwRs70eJTA=",
+                                "Dzdf3VUntY5OjGUWVOdNuSvBOlT3oFQ9cEB5XuBItyQ=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120187324\n69N5q2yGYVDIQeyUZvtDdZeI/hbUG/ANy2PWUR30Ss0=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiAw6i6OZgqLj/Sy+OFxlQH8pyJtclYB1aUgwCBmrgtRyAIgDR9OV/pn7VCWdHQIRpx5rICuPA0iwoKMpSOFvJJsVzc=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI0ODUzMmEzMzg4MmE3MTQ0MGJlYzA4MzQ0ZjkyZjMyZGVlNGI5YWFiMTlkNTA4OThmYzIzMTY5Y2UzNzU3NDgwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJSFp0RUZtNlMzV3FQMjNVcER3dU16bTdWK3JIYnpvYkE3aEc0TVRuYXh0eUFpRUE2a0thdm5UOHJDUGc2ZGFINXM0L0hYTm1jaGFnUGt3NmZkMTNVd3JzTHdFPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVlJGQjZNMkZTYm1oS2RUWm5Wa1k1V1hsS1JrSnlkMGRDTkZGWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BOZVZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWsxNVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVYwYlVWalExaGhkbXgzU3pCblJYUjFkamxqVjNOcFptTkxZemhCWkVaR01UVnFXakVLZVc1clVsVmxOSGRGYUhSWmEwd3pkV2hQUlRkTGFqZFZWbnBXZHpKNFFTdFRValJJY0VGUlZYWldRaTlHWTBSbmJIRlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlYxU0cxdUNrTjNhekZ1VVN0eGJFNU9NSEZqVlZsS2QxRkpURTVuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh4UkhsSlFRcEJRVkZFUVVWamQxSlJTV2RQYnpsWlJGVmpiMllyVWxOekwyaFBUMHhTV25jeVRHc3JUbWt3UW1JM2RDdHpjazFoVlRaM1JtaHZRMGxSUTFwM1RWZElDa2N3VURCck5VOTNZbGRNZUN0R2JrUnNlRGxzWkhSSVEyZE1Oa3g1WlVKS1dHOUJRMkpVUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFRVlFLVEZac1ZGTm5WR1pYZDJsU1prVTRWRzk0Y1dobUt6ZHZNM0ZLUlRkeFJFcHBTekp1Y2tKalpqTjNhV0YxWjNoMk4wOWxaM0JKUkUxS1JEZHVZMFYzUXdwTlVVTkNSbVZFU0VsUmNrZFFTMHB4V1c1elFXazFZM3BaY2xsSWRUVnNWVGRCV2tSclVVMDRWblZRWVhGb2JFeElUMWxrWmtGV2FDdHZTblZtUlVwQ0NtZFFRVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "SFMqM4gqcUQL7Ag0T5LzLe5LmqsZ1QiY/CMWnON1dIA="
+                },
+                "signature": "MEUCIHZtEFm6S3WqP23UpDwuMzm7V+rHbzobA7hG4MTnaxtyAiEA6kKavnT8rCPg6daH5s4/HXNmchagPkw6fd13UwrsLwE="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-amd64.exe",
+        "sha256": "c2f136916e45d3bf9c110ddfe0d3787a2e3c73e313aec983c06e03fa2caa8b3f",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-amd64.exe",
+            "Operating System": "Windows",
+            "Description": "Recommended",
+            "MD5 Sum": "e61f9b97c508b1f9817c0d343e0401ec",
+            "File Size": "28.5\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-amd64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-amd64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzTCCAlOgAwIBAgIUI2pmp6iCXDYVI/k8OmE3yLndM9swCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjI4WhcNMjUwNjE3MTg0MjI4WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERAF2Ph3qgOi5XbEEJfluzyPWgNrceJTEmjWRXJbj7N/Ggjpd4alu4AmdrVt+hlxgmbUePgGSM1ZDaiSrKsnMzKOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUseUSF2roBqu8T/9KxHbpmVhzedYwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38qAbwAAAQDAEYwRAIgTWSGjoXn5N9FR2l3/yUdGAggztPBFQz6bwUQ7XsyCskCIGgjO9LBb98EEXCzu1k9e/frBo5Uni4wVzGf3i5d4q9PMAoGCCqGSM49BAMDA2gAMGUCMCkHC9YRMXkzAzuKvP/ce+cd0BEypKvXcUqOPDrXRoMDVBd/yweJMFxJ8eKZrbkfwAIxAO9Z9ulzelvSE+5QiSQfzP4DbzvLanWLWfuFDhcvxhbMUkT4o32/+uUtdb9qmuaTkQ=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091391",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185149",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQC+X52aNLQ4ScQfCG1J38cVg+cpzshJ1JL/8XxgP/BJjAIhALHo6TNdx/pgQfqjbKS6vVMsG7eAH8ZoC/JnTn68ERhK"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120187129",
+                            "rootHash": "ZdwbPBhesDKZPZBTiEqGvdBrfAj+C/lrJFelErwFz+g=",
+                            "treeSize": "120187135",
+                            "hashes": [
+                                "R2XbZEWOcASpMtVhYcalL4twe9K9iYAqqjlSbwis2wc=",
+                                "Eli6jJnzSLFNWSf2m0z/IxkQR6JsQhL1Nzev2KGutng=",
+                                "afdKbB0gt4BFSVcDklIvl4fM87892gImZ2mMKeOtOGc=",
+                                "+LNJqikZIAy1Jjz6Nz6yXlqfsxhk4sxui5Pz5B1UAXk=",
+                                "IUO8Xpwj3q7fwpyOY66k96U1Aa2vqxBj7GIPi30pK6o=",
+                                "ubauaVR5E0AdLsg6kmCgC9207i6/YeVnvm+DjmWl7DI=",
+                                "PRh+/KW0RPNYj6ULbaej7YZeWw7M9f4hXyXiGnD8USs=",
+                                "T/Lf64kx/YyI8ymkBrFQpyo7O5jq1niKxFB/lQtFgg8=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120187135\nZdwbPBhesDKZPZBTiEqGvdBrfAj+C/lrJFelErwFz+g=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAr7wB+qX6LXnbfJGGz/yBwif0OlKPGuczudcEVbSKXvYCIQCKrum3LP5VaHaA0Lq7D2OUoRKvWROjSIrDill/HxIVzA==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJjMmYxMzY5MTZlNDVkM2JmOWMxMTBkZGZlMGQzNzg3YTJlM2M3M2UzMTNhZWM5ODNjMDZlMDNmYTJjYWE4YjNmIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJSE05MzlvNGlSQ0xBd3pFYlJiLzUwWGZaN0VtN2lnK2k3bWdteVhVU0pvUEFpQjVkUTc0M1dyUHEyR1h4WTJ0MGhmTDVoMkgxY2N5eHBIUVB6THFDTjRhTFE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4UFowRjNTVUpCWjBsVlNUSndiWEEyYVVOWVJGbFdTUzlyT0U5dFJUTjVURzVrVFRsemQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BKTkZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWtrMFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZTUVVZeVVHZ3pjV2RQYVRWWVlrVkZTbVpzZFhwNVVGZG5UbkpqWlVwVVJXMXFWMUlLV0VwaWFqZE9MMGRuYW5Ca05HRnNkVFJCYldSeVZuUXJhR3g0WjIxaVZXVlFaMGRUVFRGYVJHRnBVM0pMYzI1TmVrdFBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ6WlZWVENrWXljbTlDY1hVNFZDODVTM2hJWW5CdFZtaDZaV1JaZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh4UVdKM1FRcEJRVkZFUVVWWmQxSkJTV2RVVjFOSGFtOVlialZPT1VaU01td3pMM2xWWkVkQloyZDZkRkJDUmxGNk5tSjNWVkUzV0hONVEzTnJRMGxIWjJwUE9VeENDbUk1T0VWRldFTjZkVEZyT1dVdlpuSkNielZWYm1rMGQxWjZSMll6YVRWa05IRTVVRTFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbWRCVFVkVlEwMURhMGdLUXpsWlVrMVlhM3BCZW5WTGRsQXZZMlVyWTJRd1FrVjVjRXQyV0dOVmNVOVFSSEpZVW05TlJGWkNaQzk1ZDJWS1RVWjRTamhsUzFweVltdG1kMEZKZUFwQlR6bGFPWFZzZW1Wc2RsTkZLelZSYVZOUlpucFFORVJpZW5aTVlXNVhURmRtZFVaRWFHTjJlR2hpVFZWclZEUnZNekl2SzNWVmRHUmlPWEZ0ZFdGVUNtdFJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "wvE2kW5F07+cEQ3f4NN4ei48c+MTrsmDwG4D+iyqiz8="
+                },
+                "signature": "MEQCIHM939o4iRCLAwzEbRb/50XfZ7Em7ig+i7mgmyXUSJoPAiB5dQ743WrPq2GXxY2t0hfL5h2H1ccyxpHQPzLqCN4aLQ=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3.exe",
+        "sha256": "bbbfeef188eb39295d8d81944eba26479c8b3c87126fe4c088278e51b1d7262d",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3.exe",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "a390f9354829d3c03b7a0b29f6f57ead",
+            "File Size": "27.1\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzzCCAlSgAwIBAgIUJBR8afY/hswBWNZi3LuiaT/stkAwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjIyWhcNMjUwNjE3MTg0MjIyWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6P98qgKcbJgHl2o7uFFvs4IyC8jrS850/IQM8XJGbCcu08LSfVc1Ss8kGtO2c6hOp26e/3TdOJ0lQ08Jm2Mqc6OCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUrkkzwLC9YWRMQ83c4pHlaWEnMRMwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38p6XAAAAQDAEcwRQIgW4N2lg/oTW0aJNMgxIviG2bH87qYVqT5r9MlZ+c1h4sCIQDCBqs4oHZ6z+7n7Cc/Q8/nq9BtLZUnDiGy9cDYQMGMHjAKBggqhkjOPQQDAwNpADBmAjEA9IfeRY7bhdtCTmrmTVuJuCbVue6Zkvp+k4hRaCFcLOJbkDTLaU115/1v4QMiPjjDAjEA4Sy1W6pfMkrKmktsTPIrYtRCbyGlgPt/d8j92t3kEDvOuPDncB/tzTbNSi/Cu42d"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091081",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185143",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEYCIQD+7sdxfWKFtVIdqbtoM74Le1IxMzbIwzSaoK+PDUNkagIhAN1Dqxr6F3aO91u++/ebqmBG93pGuHAtsYWeJXfOAY92"
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120186819",
+                            "rootHash": "lwrjo2Q+iyIZlOiDXF2AAhLA2VoDOdkDv2GjCQSG9Gw=",
+                            "treeSize": "120186823",
+                            "hashes": [
+                                "fRzC3wuBh4AqQoCPcYSgFxrMajl84neaFWWmhFeVxao=",
+                                "pJDMLgOv69TiAuAKp6t934HV+tLWcIQxHAVgPnLfArE=",
+                                "m0xg4YIW/ytgXAnd620CLevnlbbaspyVHmaRhJLLxb0=",
+                                "rr4lYemA+YHkK6kAAPfPH8tUcmZVXLJZRDhA1YHBIsM=",
+                                "xzrU69bPDGEvcspCQpkpkUZHWaqmtEnQQz70d2qkObs=",
+                                "q7DkGG5R2ozOYKwUkjgUcsIh/Qg44iWov5mO2pEAwGM=",
+                                "+bmH/FRIq69zmLmW2d3BRtQ4dgd2+n+W8vAi6xkse4c=",
+                                "zADfeWeJQkX7LbvgtIGB3bSb0vIXDywqnnY7YZHMttQ=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120186823\nlwrjo2Q+iyIZlOiDXF2AAhLA2VoDOdkDv2GjCQSG9Gw=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAw5tm2h4/Cs4xWErzs9MS6JyaJhkVRtLsC79vTPCUOL8CIQCcHixVL8PruaKHF/srStw+KGJ9vFHHlZdbShIqhRDoXA==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJiYmJmZWVmMTg4ZWIzOTI5NWQ4ZDgxOTQ0ZWJhMjY0NzljOGIzYzg3MTI2ZmU0YzA4ODI3OGU1MWIxZDcyNjJkIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURwV2hjUWV1Q21BUUZseWhnTC9MUE9ySnFWZUxrWVVEQnV6U1pWRVpaN1pBSWhBSWdkZDBJMFRPVTZsWXRjRVYxZXB4anJRMGVPTEltQWUxL1gxdk9MVWQxYiIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZla05EUVd4VFowRjNTVUpCWjBsVlNrSlNPR0ZtV1M5b2MzZENWMDVhYVROTWRXbGhWQzl6ZEd0QmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BKZVZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWtsNVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVUyVURrNGNXZExZMkpLWjBoc01tODNkVVpHZG5NMFNYbERPR3B5VXpnMU1DOUpVVTBLT0ZoS1IySkRZM1V3T0V4VFpsWmpNVk56T0d0SGRFOHlZelpvVDNBeU5tVXZNMVJrVDBvd2JGRXdPRXB0TWsxeFl6WlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ5YTJ0NkNuZE1RemxaVjFKTlVUZ3pZelJ3U0d4aFYwVnVUVkpOZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh3TmxoQlFRcEJRVkZFUVVWamQxSlJTV2RYTkU0eWJHY3ZiMVJYTUdGS1RrMW5lRWwyYVVjeVlrZzROM0ZaVm5GVU5YSTVUV3hhSzJNeGFEUnpRMGxSUkVOQ2NYTTBDbTlJV2paNkt6ZHVOME5qTDFFNEwyNXhPVUowVEZwVmJrUnBSM2s1WTBSWlVVMUhUVWhxUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV3UVVSQ2JVRnFSVUVLT1VsbVpWSlpOMkpvWkhSRFZHMXliVlJXZFVwMVEySldkV1UyV210MmNDdHJOR2hTWVVOR1kweFBTbUpyUkZSTVlWVXhNVFV2TVhZMFVVMXBVR3BxUkFwQmFrVkJORk41TVZjMmNHWk5hM0pMYld0MGMxUlFTWEpaZEZKRFlubEhiR2RRZEM5a09HbzVNblF6YTBWRWRrOTFVRVJ1WTBJdmRIcFVZazVUYVM5RENuVTBNbVFLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "u7/u8YjrOSldjYGUTromR5yLPIcSb+TAiCeOUbHXJi0="
+                },
+                "signature": "MEYCIQDpWhcQeuCmAQFlyhgL/LPOrJqVeLkYUDBuzSZVEZZ7ZAIhAIgdd0I0TOU6lYtcEV1epxjrQ0eOLImAe1/X1vOLUd1b"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-arm64.exe",
+        "sha256": "552e0d5c37e0013407c20d9bdd041b28f41316302c5420d8bef703509cffe4ba",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-arm64.exe",
+            "Operating System": "Windows",
+            "Description": "Experimental",
+            "MD5 Sum": "52cbdc88bd81bf681b23ca2e2c5b47b9",
+            "File Size": "27.7\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-arm64.exe.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-arm64.exe.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlSgAwIBAgIUYfEa6y0+cDUlqClGL++Fh4q2lwAwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjIxWhcNMjUwNjE3MTg0MjIxWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElw6quxoms/5H5BJNg1QIqmXz/Zt2Ezx/RbSQQzOPxkKFThwLD0GErkDITE+DYIUbUfrne4oOyinREaCKfX1mEaOCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUmUNpWOqbvJTT5UKcUyFCSe6kJgIwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38p4yIAAAQDAEcwRQIhAOKfpvaIBNqfj9NSx9DrykbN8gbOIOigwicTUhjWnSCfAiAtqvndLiWTMiKDqVbVSklgKjDMDFvEq35RP0Q3qTE7NTAKBggqhkjOPQQDAwNoADBlAjAmt9/pe6MY3LFDd+FfvqDA9iY8v2t37Nu0r0GeMkCwZz3taDnIpiqqYWHjYyyWwNUCMQDWxaSl/oh0QroOoOUH2O0MbJAeTza0SEK8FAlF2ZCVh7NRHVO6ELcRAyNGlhgv0+M="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242090985",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185141",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQDw1fDqZ0oEk37KJBlFugl0f24jMYo8m3FTPpc18gwoLAIgSDNSM4uRy5KOET7qI79TEdFTRu7XeAgRH0K0xD0qdcA="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120186723",
+                            "rootHash": "k2u/HshCdgkt3pksbQfWA0uMO1EIzvUlu9IPbURkoiI=",
+                            "treeSize": "120186735",
+                            "hashes": [
+                                "9P0EnL+KndehVZM9ZD7of0WaMUsd48YTAXzo75Vhi3k=",
+                                "n7N1A/NvckKmBWIITEaRDs9FH+vC2zkjPzM4EgBESEo=",
+                                "o68aXTaKnF8zqavenni5enCIbQtCPi7VFFqy5lQUeGg=",
+                                "9ZCRNHoKw8sU8FN1zmGfLkjMgramjRqhYRr8llZcM+M=",
+                                "DKrUf5bgxSmLjg+t6Vgp14o0sa0A+Yb4VNv3CyjLcRI=",
+                                "xV/SNwNAiOQ6R9qUECI5zNyMqXNlrPSlb0FJ9YYbk40=",
+                                "q7DkGG5R2ozOYKwUkjgUcsIh/Qg44iWov5mO2pEAwGM=",
+                                "+bmH/FRIq69zmLmW2d3BRtQ4dgd2+n+W8vAi6xkse4c=",
+                                "zADfeWeJQkX7LbvgtIGB3bSb0vIXDywqnnY7YZHMttQ=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120186735\nk2u/HshCdgkt3pksbQfWA0uMO1EIzvUlu9IPbURkoiI=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEA1h/x//gAiLgEKWKUbfnHjKHAsulAwlXU+RwyZfN96hkCIQC6CubA4cdNfxpH50BpzN66DxHpNcdJZ4laxCIvWAxv4g==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI1NTJlMGQ1YzM3ZTAwMTM0MDdjMjBkOWJkZDA0MWIyOGY0MTMxNjMwMmM1NDIwZDhiZWY3MDM1MDljZmZlNGJhIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURhalpmLzhyUWdqcm5DOFlmZU5pKzFHVmxoNGFmMXBGdC9KclN2Kzdtb0JRSWhBS1Q1VUM4M2l2ZXZPMkxUdCt1dEtsc3JDL1JkeW9INjdnb1RxMHp2dlkwUCIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4VFowRjNTVUpCWjBsVldXWkZZVFo1TUN0alJGVnNjVU5zUjB3ckswWm9OSEV5YkhkQmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BKZUZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWtsNFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZzZHpaeGRYaHZiWE12TlVnMVFrcE9aekZSU1hGdFdIb3ZXblF5UlhwNEwxSmlVMUVLVVhwUFVIaHJTMFpVYUhkTVJEQkhSWEpyUkVsVVJTdEVXVWxWWWxWbWNtNWxORzlQZVdsdVVrVmhRMHRtV0RGdFJXRlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ0VlU1d0NsZFBjV0oyU2xSVU5WVkxZMVY1UmtOVFpUWnJTbWRKZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh3TkhsSlFRcEJRVkZFUVVWamQxSlJTV2hCVDB0bWNIWmhTVUpPY1dacU9VNVRlRGxFY25scllrNDRaMkpQU1U5cFozZHBZMVJWYUdwWGJsTkRaa0ZwUVhSeGRtNWtDa3hwVjFSTmFVdEVjVlppVmxOcmJHZExha1JOUkVaMlJYRXpOVkpRTUZFemNWUkZOMDVVUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV2UVVSQ2JFRnFRVzBLZERrdmNHVTJUVmt6VEVaRVpDdEdablp4UkVFNWFWazRkakowTXpkT2RUQnlNRWRsVFd0RGQxcDZNM1JoUkc1SmNHbHhjVmxYU0dwWmVYbFhkMDVWUXdwTlVVUlhlR0ZUYkM5dmFEQlJjbTlQYjA5VlNESlBNRTFpU2tGbFZIcGhNRk5GU3poR1FXeEdNbHBEVm1nM1RsSklWazgyUlV4alVrRjVUa2RzYUdkMkNqQXJUVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "VS4NXDfgATQHwg2b3QQbKPQTFjAsVCDYvvcDUJz/5Lo="
+                },
+                "signature": "MEYCIQDajZf/8rQgjrnC8YfeNi+1GVlh4af1pFt/JrSv+7moBQIhAKT5UC83ivevO2LTt+utKlsrC/RdyoH67goTq0zvvY0P"
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-amd64.zip",
+        "sha256": "a8dcd27176706093062faaa9c9e2894a19e226eb708a61944e0d38f6c6662a7e",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-amd64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "24384923aba2bb0e97da2784951da014",
+            "File Size": "11.4\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-amd64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-amd64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzjCCAlOgAwIBAgIUGBU9Arv000yGi0QycVNG/IGvHrYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjI1WhcNMjUwNjE3MTg0MjI1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5qWMljdTo8tcXW7YzQZdwVUN5pyIRCLQlct7m12cnoZL1Orogp9XM7vfqRnzSeOj8J59FJWm158XSPprS8YIPKOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQURLiShUdhn7sK9owQgMslaK0z274wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38p9VcAAAQDAEYwRAIgeDDFOKSHW+yw61vNtcoIsjpmDKp2hx7Lgy8ChxxjIg4CIC+yiPcYCvy2UBjtu+gmH8perm8CijhsnGUvNfUAl6z4MAoGCCqGSM49BAMDA2kAMGYCMQDzfP42Y1s/QEHl+MxkW5GEJNaCJz/NSYiGiegVnNVWcYf6MuLdCgX12YD1CbcVY04CMQCdOxzu/uJFF1xV44wCXAhgQjUf6Q7POdWa12C0hCr85pjjgOeWir4OId3XUqy44v4="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091238",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185145",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQCQDqJhdoRga4Br4F3dB8tNMs9IwUdmX2nOhvEAPO4d3AIgLcsX91a0xbo7baUpaq7KTxwQPchtK8eQxLYXQF2qPgQ="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120186976",
+                            "rootHash": "1KJZ0eRlCGyv01X2n901e5rBNeBVpe7q3YJQvDm7mFw=",
+                            "treeSize": "120186984",
+                            "hashes": [
+                                "pwfwoHG0aAKtod3XRdtXdHfprDBF2zPc+1emfS/z4zs=",
+                                "bFUIJ+zHbPMLrWS16bA+TR0aV3D7X4al53azSxzszyo=",
+                                "Z2d1Ln5vceKxImlPwuSAfHXp7NIap0l1Qm+iDpkVl6U=",
+                                "Vi7uunH72dFoUEpBwxqRTrZmGluFqdwI1C42d+bOTbQ=",
+                                "go/GoNMG3BEgXBUWE3z7BL54iNlmYEeLM0mXxMWq6cA=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120186984\n1KJZ0eRlCGyv01X2n901e5rBNeBVpe7q3YJQvDm7mFw=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiAgm4DZQGiHxpeMrf1n+pZybuogs4IxvQaT+yWAdecL4wIhAJfuvtqPdmduF4QuLTWO0m3y8nMgFfa0LAxIxirH8dYl\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJhOGRjZDI3MTc2NzA2MDkzMDYyZmFhYTljOWUyODk0YTE5ZTIyNmViNzA4YTYxOTQ0ZTBkMzhmNmM2NjYyYTdlIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJREpUZSsxSjgyUlhVY3dtMEdaQk5GbWhyMVlhMmNjcXh4RkE1MEd6V1lBREFpRUFobVE1UGRQc1JuS09XS1k1ODdQMVU0VUZuZ1dJcGtiZ0p6azQyTklMWFJnPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZha05EUVd4UFowRjNTVUpCWjBsVlIwSlZPVUZ5ZGpBd01IbEhhVEJSZVdOV1RrY3ZTVWQyU0hKWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BKTVZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWtreFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVUxY1ZkTmJHcGtWRzg0ZEdOWVZ6ZFplbEZhWkhkV1ZVNDFjSGxKVWtOTVVXeGpkRGNLYlRFeVkyNXZXa3d4VDNKdlozQTVXRTAzZG1aeFVtNTZVMlZQYWpoS05UbEdTbGR0TVRVNFdGTlFjSEpUT0ZsSlVFdFBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZTVEdsVENtaFZaR2h1TjNOTE9XOTNVV2ROYzJ4aFN6QjZNamMwZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh3T1ZaalFRcEJRVkZFUVVWWmQxSkJTV2RsUkVSR1QwdFRTRmNyZVhjMk1YWk9kR052U1hOcWNHMUVTM0F5YUhnM1RHZDVPRU5vZUhocVNXYzBRMGxESzNscFVHTlpDa04yZVRKVlFtcDBkU3RuYlVnNGNHVnliVGhEYVdwb2MyNUhWWFpPWmxWQmJEWjZORTFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbXRCVFVkWlEwMVJSSG9LWmxBME1sa3hjeTlSUlVoc0swMTRhMWMxUjBWS1RtRkRTbm92VGxOWmFVZHBaV2RXYms1V1YyTlpaalpOZFV4a1EyZFlNVEpaUkRGRFltTldXVEEwUXdwTlVVTmtUM2g2ZFM5MVNrWkdNWGhXTkRSM1ExaEJhR2RSYWxWbU5sRTNVRTlrVjJFeE1rTXdhRU55T0RWd2FtcG5UMlZYYVhJMFQwbGtNMWhWY1hrMENqUjJORDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "qNzScXZwYJMGL6qpyeKJShniJutwimGUTg049sZmKn4="
+                },
+                "signature": "MEUCIDJTe+1J82RXUcwm0GZBNFmhr1Ya2ccqxxFA50GzWYADAiEAhmQ5PdPsRnKOWKY587P1U4UFngWIpkbgJzk42NILXRg="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-win32.zip",
+        "sha256": "d18b1a3f41f6394bc3cdcb4055f1fff50f122b870491be82476d11b42afe487e",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-win32.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "d049d71822df1fdcc8360c747d8d0759",
+            "File Size": "10.1\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-win32.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-win32.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzDCCAlOgAwIBAgIUeeW4eO8/F6odQiBlqwhq/2GJdrAwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjE3MTgzMjI0WhcNMjUwNjE3MTg0MjI0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf04pIXOlYpqhK9PO6W0eR+CNJ5fk1ikF2j582UAcIaKe7mq2xFpVSaGx+RupN/Oh8lBNJ5+vFuMSFUpCvA5kbqOCAXIwggFuMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUrFRSjAAXVF2I3c6cbRmrZKopp/AwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPaHVnb0BweXRob24ub3JnMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiQYKKwYBBAHWeQIEAgR7BHkAdwB1AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABl38p76EAAAQDAEYwRAIgNtmABoID5QMyFv7nhKPnD7qQCNesdXWCq0oM4Sw9sLQCIBZ/RRoIASMD0Y6b8h8v2PVBVHK2gnKNnKwv2TNWi51iMAoGCCqGSM49BAMDA2cAMGQCMHPUwLuqWDWuzumQJVLajPbfCSPE9OmBKCH4d7MGBEMOZTfld0Ds8VQzmM2uWINQTAIwL6vaHKMGf40puzFqIcvel5ztXKdQ2sArSff5ZXHbiNmIcum2tdvJTCzZn1lgIg8U"
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091160",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185144",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQDKmA5SFgkeJqxxWmiP+BACRspTvBj2wU3CRIwfPhLGbAIgPmP/pbARj/gOtKkQvM8ZlNMKQY8xZklnqjns74s4Lq4="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120186898",
+                            "rootHash": "1rUpx8RXiTl6ZFpSV17nxTwoG60HnYd56iQPbML8kBw=",
+                            "treeSize": "120186906",
+                            "hashes": [
+                                "5MxuQb326Ywoj/TcM4VaqQZNHupCiwq9ma6QneFcDt4=",
+                                "aU7VeNRyOJYEC0IEXQFrVYkd4O/dISv3Hnnun6qt3t4=",
+                                "wD2b4iEZe7dQR3FQxoIrdPMJu3Yd31ghkpp96psmpBY=",
+                                "wMcDB4sdkJzhIGOp8A3StFRCKcXaBq6gK0CiokR7dvU=",
+                                "08EOn6q9i6zbyW6AMujzKjSiWDfoX//bxop8YLIRlbo=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120186906\n1rUpx8RXiTl6ZFpSV17nxTwoG60HnYd56iQPbML8kBw=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEAtfKLTCJ0wG9Ys27cDRQLOUaPvUGamE2tRQ365Dc3lv4CIBgKahVAO3/wKDxyQDVvUsZreTVDJwGSINVAIlbQTZE7\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJkMThiMWEzZjQxZjYzOTRiYzNjZGNiNDA1NWYxZmZmNTBmMTIyYjg3MDQ5MWJlODI0NzZkMTFiNDJhZmU0ODdlIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJSFBnVFRIbDBXanpHR0lWMFhmZ0JZbmJuSFhKRkQ2VFFnNzF0RFgraC9sYkFpQnVDUmEyWC9TK0t2N0dsQlBsMUZvMW1GNXNLejJrOFhFbjE3Ti9xZGdZNnc9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZSRU5EUVd4UFowRjNTVUpCWjBsVlpXVlhOR1ZQT0M5R05tOWtVV2xDYkhGM2FIRXZNa2RLWkhKQmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUlROTlZHZDZUV3BKTUZkb1kwNU5hbFYzVG1wRk0wMVVaekJOYWtrd1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZtTURSd1NWaFBiRmx3Y1doTE9WQlBObGN3WlZJclEwNUtOV1pyTVdsclJqSnFOVGdLTWxWQlkwbGhTMlUzYlhFeWVFWndWbE5oUjNnclVuVndUaTlQYURoc1FrNUtOU3QyUm5WTlUwWlZjRU4yUVRWclluRlBRMEZZU1hkblowWjFUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ5UmxKVENtcEJRVmhXUmpKSk0yTTJZMkpTYlhKYVMyOXdjQzlCZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlVaFdibUl3UW5kbFdGSnZZakkwZFdJelNtNU5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVZGWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpjS1FraHJRV1IzUWpGQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNNemh3TnpaRlFRcEJRVkZFUVVWWmQxSkJTV2RPZEcxQlFtOUpSRFZSVFhsR2RqZHVhRXRRYmtRM2NWRkRUbVZ6WkZoWFEzRXdiMDAwVTNjNWMweFJRMGxDV2k5U1VtOUpDa0ZUVFVRd1dUWmlPR2c0ZGpKUVZrSldTRXN5WjI1TFRtNUxkM1l5VkU1WGFUVXhhVTFCYjBkRFEzRkhVMDAwT1VKQlRVUkJNbU5CVFVkUlEwMUlVRlVLZDB4MWNWZEVWM1Y2ZFcxUlNsWk1ZV3BRWW1aRFUxQkZPVTl0UWt0RFNEUmtOMDFIUWtWTlQxcFVabXhrTUVSek9GWlJlbTFOTW5WWFNVNVJWRUZKZHdwTU5uWmhTRXROUjJZME1IQjFla1p4U1dOMlpXdzFlblJZUzJSUk1uTkJjbE5tWmpWYVdFaGlhVTV0U1dOMWJUSjBaSFpLVkVONldtNHhiR2RKWnpoVkNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "0YsaP0H2OUvDzctAVfH/9Q8SK4cEkb6CR20RtCr+SH4="
+                },
+                "signature": "MEQCIHPgTTHl0WjzGGIV0XfgBYnbnHXJFD6TQg71tDX+h/lbAiBuCRa2X/S+Kv7GlBPl1Fo1mF5sKz2k8XEn17N/qdgY6w=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-arm64.zip",
+        "sha256": "7eba03bb295d422547ad29e67b88a073311c86f6c4fed6cce9b6af6b9e71d666",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-arm64.zip",
+            "Operating System": "Windows",
+            "Description": null,
+            "MD5 Sum": "8d2aaeea0bad5f7b2c1e31ae590230a7",
+            "File Size": "10.6\u00a0MB",
+            "Sigstore": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-arm64.zip.sigstore",
+            "SBOM": "https://www.python.org/ftp/python/3.14.0/python-3.14.0b3-embed-arm64.zip.spdx.json"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzTCCAlKgAwIBAgITdIvrFqqcqB1yVIX+L17xXSu9SDAKBggqhkjOPQQDAzA3MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxHjAcBgNVBAMTFXNpZ3N0b3JlLWludGVybWVkaWF0ZTAeFw0yNTA2MTcxODMyMjdaFw0yNTA2MTcxODQyMjdaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATvODZryH9AACE7x0MEVN24Ma/E/kvMj1DMN7QvNh+EXGC2/2K6yOKTZgGyvJ8R7Y4qy/lRvTeSJvMeHzI5jNk2o4IBcjCCAW4wDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMB0GA1UdDgQWBBRrpI9hVENIoHkXqkgJptKYDIJHuzAfBgNVHSMEGDAWgBTf0+nPViQRlvmo2OkoVaLGLhhkPzAdBgNVHREBAf8EEzARgQ9odWdvQHB5dGhvbi5vcmcwLAYKKwYBBAGDvzABAQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMC4GCisGAQQBg78wAQgEIAweaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGXfyn7cQAABAMARjBEAiAnV4T4n3NV4oKmtFwODoDJY76C39Lm9HkJQQqfVy3K8QIgRPdsAKqV2/BJjY6RyVQ/Q9PpAPtNbW+teVBL04IcfLMwCgYIKoZIzj0EAwMDaQAwZgIxANuCtVqHLM6Shcm+MV8aBrh8RnaIXjfwXJy+7zZj/5+CBYHxdPQRbj2v5xYNGKJdRAIxAOWQvu//gcPXEYViadTY3hVLnKyP1xEpHxPWqpsBdUnPc7EIUCZvCB5cvEPUsOpuuw=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "242091306",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1750185147",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEQCIHh1f0HotI4Zg52xr+JywP4tjzWdJhu89P34VxEKo9WvAiBluVmE/efN6+mfbccs3mcB4c2CtsFMi2L0d4zku9mwRQ=="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "120187044",
+                            "rootHash": "RI7NGMjXKaci7F8FoZHBbkA4MiBwKu6LFnNErtf92y8=",
+                            "treeSize": "120187052",
+                            "hashes": [
+                                "DFuVjoY/R7i+DHRZWWh8YeeQra7jYFMx5JoyugkANb8=",
+                                "LtJ2bJBmBnhwFA1JODaUXQ7n9KxnNAFWsNpjIrPw+2w=",
+                                "m8K13Q5/k69ccguw2xC995FnBM+tFK1lzxhkCd/2WGM=",
+                                "6gRwqxLc6/eaVaHEqIHy2FQgotaglHSOPd6AiOvEilw=",
+                                "qHMuW/LAroJhRvlfNA9hrARKXI8w1rwhSVP+XhMAH04=",
+                                "T/Lf64kx/YyI8ymkBrFQpyo7O5jq1niKxFB/lQtFgg8=",
+                                "MXZlUSu/Nk7JpWtrdLdZirJdEm6r3KeotdNfHkWFyM0=",
+                                "Xanu/6JDW+tIz/8FFY8TJPCZiE6sjMezuSP4ZfaLcZ4=",
+                                "JdwKuHIKaaHCnH9lvllhnLwhBLTmddg+MU5yF4JyNzM=",
+                                "kGVUE6qTDBZjmi+ni1oCZ/vG1EIHaX70wibrOLr/kaE=",
+                                "K4ASfjQwnhSONRPPue7LdN9Bo2+tUa4Qg8L15TBPj9w=",
+                                "hUheZicPpMZOVzj8LjHwP6aJKl9Qi7zGSbQdh4BJHY0=",
+                                "ISIUCBBJSSuzXkkGRbwU0pJSpWliMh4Zvol1m+9gd/U=",
+                                "63G35ZWA2JgOE3bXu0oKhro3tiR4IDPH1IgMp21/pjk=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n120187052\nRI7NGMjXKaci7F8FoZHBbkA4MiBwKu6LFnNErtf92y8=\n\n\u2014 rekor.sigstore.dev wNI9ajBGAiEAjHB8F42pNYTyc3vr1EwZ/6iU+J44SnwdDJAlisHu33cCIQCYvaEmYRFND6F/jvHvRo5TsslFqg8A7GRLWkr2uCw9aw==\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3ZWJhMDNiYjI5NWQ0MjI1NDdhZDI5ZTY3Yjg4YTA3MzMxMWM4NmY2YzRmZWQ2Y2NlOWI2YWY2YjllNzFkNjY2In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUUNBc0ZOK0U2bWZwdzA5T2ZkZnlyK0lQYkppOXNiZHp4TzZWNXpwS1dkbmp3SWdGRWE2Z0xkb1Bod1lGOVJ5cEdENmdtejBXa0hvQ3dOTHB4cWdJbS82b2NZPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4TFowRjNTVUpCWjBsVVpFbDJja1p4Y1dOeFFqRjVWa2xZSzB3eE4zaFlVM1U1VTBSQlMwSm5aM0ZvYTJwUFVGRlJSRUY2UVRNS1RWSlZkMFYzV1VSV1VWRkxSWGQ0ZW1GWFpIcGtSemw1V2xNMWExcFlXWGhJYWtGalFtZE9Wa0pCVFZSR1dFNXdXak5PTUdJelNteE1WMngxWkVkV2VRcGlWMVpyWVZkR01GcFVRV1ZHZHpCNVRsUkJNazFVWTNoUFJFMTVUV3BrWVVaM01IbE9WRUV5VFZSamVFOUVVWGxOYW1SaFRVRkJkMWRVUVZSQ1oyTnhDbWhyYWs5UVVVbENRbWRuY1docmFrOVFVVTFDUW5kT1EwRkJWSFpQUkZweWVVZzVRVUZEUlRkNE1FMUZWazR5TkUxaEwwVXZhM1pOYWpGRVRVNDNVWFlLVG1nclJWaEhRekl2TWtzMmVVOUxWRnBuUjNsMlNqaFNOMWswY1hrdmJGSjJWR1ZUU25aTlpVaDZTVFZxVG1zeWJ6UkpRbU5xUTBOQlZ6UjNSR2RaUkFwV1VqQlFRVkZJTDBKQlVVUkJaMlZCVFVKTlIwRXhWV1JLVVZGTlRVRnZSME5EYzBkQlVWVkdRbmROUkUxQ01FZEJNVlZrUkdkUlYwSkNVbkp3U1Rsb0NsWkZUa2x2U0d0WWNXdG5TbkIwUzFsRVNVcElkWHBCWmtKblRsWklVMDFGUjBSQlYyZENWR1l3SzI1UVZtbFJVbXgyYlc4eVQydHZWbUZNUjB4b2FHc0tVSHBCWkVKblRsWklVa1ZDUVdZNFJVVjZRVkpuVVRsdlpGZGtkbEZJUWpWa1IyaDJZbWsxZG1OdFkzZE1RVmxMUzNkWlFrSkJSMFIyZWtGQ1FWRlJaUXBoU0ZJd1kwaE5Oa3g1T1c1aFdGSnZaRmRKZFZreU9YUk1NbmgyV2pKc2RVd3lPV2hrV0ZKdlRVTTBSME5wYzBkQlVWRkNaemM0ZDBGUlowVkpRWGRsQ21GSVVqQmpTRTAyVEhrNWJtRllVbTlrVjBsMVdUSTVkRXd5ZUhaYU1teDFUREk1YUdSWVVtOU5TVWRLUW1kdmNrSm5SVVZCWkZvMVFXZFJRMEpJYzBVS1pWRkNNMEZJVlVFelZEQjNZWE5pU0VWVVNtcEhValJqYlZkak0wRnhTa3RZY21wbFVFc3pMMmcwY0hsblF6aHdOMjgwUVVGQlIxaG1lVzQzWTFGQlFRcENRVTFCVW1wQ1JVRnBRVzVXTkZRMGJqTk9WalJ2UzIxMFJuZFBSRzlFU2xrM05rTXpPVXh0T1VoclNsRlJjV1pXZVROTE9GRkpaMUpRWkhOQlMzRldDakl2UWtwcVdUWlNlVlpSTDFFNVVIQkJVSFJPWWxjcmRHVldRa3d3TkVsalpreE5kME5uV1VsTGIxcEplbW93UlVGM1RVUmhVVUYzV21kSmVFRk9kVU1LZEZaeFNFeE5ObE5vWTIwclRWWTRZVUp5YURoU2JtRkpXR3BtZDFoS2VTczNlbHBxTHpVclEwSlpTSGhrVUZGU1ltb3lkalY0V1U1SFMwcGtVa0ZKZUFwQlQxZFJkblV2TDJkalVGaEZXVlpwWVdSVVdUTm9Wa3h1UzNsUU1YaEZjRWg0VUZkeGNITkNaRlZ1VUdNM1JVbFZRMXAyUTBJMVkzWkZVRlZ6VDNCMUNuVjNQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ]
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "froDuyldQiVHrSnme4igczEchvbE/tbM6bava55x1mY="
+                },
+                "signature": "MEUCIQCAsFN+E6mfpw09Ofdfyr+IPbJi9sbdzxO6V5zpKWdnjwIgFEa6gLdoPhwYF9RypGD6gmz0WkHoCwNLpxqgIm/6ocY="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.14.0/windows-3.14.0b3.json",
+        "sha256": "327087eb9888fcb7813d080f4b45a526e3e345c389fb1ca1c04026c907b30e1d",
+        "release_url": "https://www.python.org/downloads/release/python-3140b3/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.14.0/windows-3.14.0b3.json",
+            "Operating System": "Windows",
+            "Description": "Install with 'py install 3.14-dev'",
+            "MD5 Sum": "4197ABEF576A4B1E06C2AAE85DFCC8B5",
+            "File Size": "15.3\u00a0KB",
+            "Sigstore": null,
+            "SBOM": null
+        }
+    }
+]

--- a/versions/3.9.23.json
+++ b/versions/3.9.23.json
@@ -1,0 +1,143 @@
+[
+    {
+        "url": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tgz",
+        "sha256": "9a69aad184dc1d06f6819930741da3a328d34875a41f8ba33875774dbfc51b51",
+        "release_url": "https://www.python.org/downloads/release/python-3923/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tgz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "e6c3c5ba679cc6a1e2932b2fdcafbc3d",
+            "File Size": "24.9\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tgz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tgz.sigstore"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIICzTCCAlSgAwIBAgIUSfg9vXBgYShxtjyPqhpHHB9KFYEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTkyMDM2WhcNMjUwNjAzMTkzMDM2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmsv0qoMWyKRQspumJ+qf2SMh9+xst1eoPyy9+mcWS+GOb0RJ4GRmGDfuSHdFH6NOEN65pJKVxwZCeFHNDtBa16OCAXMwggFvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUfmsBEAHYMchI8Bd/T7edbAu2iPIwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPbHVrYXN6QGxhbmdhLnBsMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlzc9CQYAAAQDAEcwRQIgRiBeM4kxhknKh+uGCM3Zd+Vemw9rvYa+JZ3b3kybyqECIQCzqZSMvSicZg90qky6ENzOJ96X4AQq2OgV/O8SmZWDmTAKBggqhkjOPQQDAwNnADBkAjA4HUM2UMP+wOQkh6jG9uLT+Vk6+VjvIPOrQJ7wVHhiy2aHr67K/mZN4VQbVfEngtgCMHjSAj0j8lepsbWODf/9z0xP0fcKoP1QuESdIpaacKDkmiTPGL8HIap5U5weyAu+TQ=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228949351",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748978436",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCICdGEu1tqYyyUv3Xp6jPm4mclS6wH3l9mba6nYFRaw/aAiEAt+AFM70mwRyN27qGpt7uq7PswtBqsL7/WkcJiJU5ZOc="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107045089",
+                            "rootHash": "SfTOzJ1bs2ZFVtOR9WOvl36+Kih4u/UF72HtNcnsg48=",
+                            "treeSize": "107045091",
+                            "hashes": [
+                                "8JG1ZWztXf+ZGGWo04aBQwonq5lrhhqjUX2190wz77Y=",
+                                "+OvAMqwuu++rpkujRrXqaGeNCOf1q7URgIE/9heGaGY=",
+                                "WlFF7YY7EE59pTttjRbAYVTBl8HQqlzSme5efU2HDoA=",
+                                "SWovOGgTT4rV86781OSrVsURR0R2HlbnHXkzaxCA6cU=",
+                                "WReul2NpmJe9lyAN3iFnNwqQxYl/rFzRikjkWy4KJks=",
+                                "mAX/zvx1jR0ujLtDApsQpHyxmoDGidClHMOn0BX1aQA=",
+                                "u5LKLBPTYgXZg0fBi6/8LuEeNy3EBAxJF0AkkB4Co6E=",
+                                "SPUVncwJRVX/n/RICCYqLpAzraqx7S0eMdXRr1RLRgg=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107045091\nSfTOzJ1bs2ZFVtOR9WOvl36+Kih4u/UF72HtNcnsg48=\n\n\u2014 rekor.sigstore.dev wNI9ajBEAiB7+60rpMMtzYPUh3+kOZr/8BjAr5ung9orO7zpufFbswIgYb+BvISRdPK/zUz0mCBABK/sHzY91nt7VHjQphXyyas=\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI5YTY5YWFkMTg0ZGMxZDA2ZjY4MTk5MzA3NDFkYTNhMzI4ZDM0ODc1YTQxZjhiYTMzODc1Nzc0ZGJmYzUxYjUxIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQnM3Y3d5aGF2VlQ1TGVyTVJlNXF5UDFGZGw2cVdCWVZTdXExeUlnSnY0ZUFpQi9mckQrNGhmbTZIYzFudThqY0NyUmNGYlk2dWllNDYzQUh3aDBjMjM0QUE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTjZWRU5EUVd4VFowRjNTVUpCWjBsVlUyWm5PWFpZUW1kWlUyaDRkR3A1VUhGb2NFaElRamxMUmxsRmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHdDVUVVJOTWxkb1kwNU5hbFYzVG1wQmVrMVVhM3BOUkUweVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZ0YzNZd2NXOU5WM2xMVWxGemNIVnRTaXR4WmpKVFRXZzVLM2h6ZERGbGIxQjVlVGtLSzIxalYxTXJSMDlpTUZKS05FZFNiVWRFWm5WVFNHUkdTRFpPVDBWT05qVndTa3RXZUhkYVEyVkdTRTVFZEVKaE1UWlBRMEZZVFhkblowWjJUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZtYlhOQ0NrVkJTRmxOWTJoSk9FSmtMMVEzWldSaVFYVXlhVkJKZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlraFdjbGxZVGpaUlIzaG9ZbTFrYUV4dVFuTk5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVdkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWpnS1FraHZRV1ZCUWpKQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNlbU01UTFGWlFRcEJRVkZFUVVWamQxSlJTV2RTYVVKbFRUUnJlR2hyYmt0b0szVkhRMDB6V21RclZtVnRkemx5ZGxsaEswcGFNMkl6YTNsaWVYRkZRMGxSUTNweFdsTk5DblpUYVdOYVp6a3djV3Q1TmtWT2VrOUtPVFpZTkVGUmNUSlBaMVl2VHpoVGJWcFhSRzFVUVV0Q1oyZHhhR3RxVDFCUlVVUkJkMDV1UVVSQ2EwRnFRVFFLU0ZWTk1sVk5VQ3QzVDFGcmFEWnFSemwxVEZRclZtczJLMVpxZGtsUVQzSlJTamQzVmtob2FYa3lZVWh5TmpkTEwyMWFUalJXVVdKV1prVnVaM1JuUXdwTlNHcFRRV293YWpoc1pYQnpZbGRQUkdZdk9Yb3dlRkF3Wm1OTGIxQXhVWFZGVTJSSmNHRmhZMHRFYTIxcFZGQkhURGhJU1dGd05WVTFkMlY1UVhVckNsUlJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0="
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "mmmq0YTcHQb2gZkwdB2joyjTSHWkH4ujOHV3Tb/FG1E="
+                },
+                "signature": "MEQCIBs7cwyhavVT5LerMRe5qyP1Fdl6qWBYVSuq1yIgJv4eAiB/frD+4hfm6Hc1nu8jcCrRcFbY6uie463AHwh0c234AA=="
+            }
+        }
+    },
+    {
+        "url": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz",
+        "sha256": "61a42919e13d539f7673cf11d1c404380e28e540510860b9d242196e165709c9",
+        "release_url": "https://www.python.org/downloads/release/python-3923/",
+        "raw": {
+            "Version": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz",
+            "Operating System": "Source release",
+            "Description": null,
+            "MD5 Sum": "a4e4a53cbde60b743d7c2f9aa38c3b8f",
+            "File Size": "18.7\u00a0MB",
+            "GPG": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz.asc",
+            "Sigstore": "https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz.sigstore"
+        },
+        "sigstore": {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {
+                    "rawBytes": "MIIC0DCCAlWgAwIBAgIUG229RKhIVHHNhr+bZV55P8F/JiYwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUwNjAzMTkyMDQ1WhcNMjUwNjAzMTkzMDQ1WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHAdkk3GmQSTLHaA3qgs8Mto97OSVbVhaNbzSF2eatgDIKJUkUF9BFqx+RKVYbHU5FQJHdwA5T67OfhaDYHiyaqOCAXQwggFwMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUaB0HmIo69ITnU91ryuyAKS4hsbgwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHQYDVR0RAQH/BBMwEYEPbHVrYXN6QGxhbmdhLnBsMCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABlzc9LZwAAAQDAEgwRgIhAKVxDJnomsWJaXHsKKu19qVvfaPnwK5YQXGoI9SKn+NJAiEA+CLl5/VDMS+UMV8Nh+89J2zcpcypEhw6C4tW1BCCuDAwCgYIKoZIzj0EAwMDaQAwZgIxAICtnwUolcM1gk7JBamvFMSw9K1YXhTaErgTVTlJK+pVy7GnuG9sFdBAo1cu2l8KpwIxAPa0s2b6co6pQfHxXbTADBsp4WT6YmiW7A+92JlwY87vD+7dP1rKzW3NWRZOE5BnqQ=="
+                },
+                "tlogEntries": [
+                    {
+                        "logIndex": "228949549",
+                        "logId": {
+                            "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+                        },
+                        "kindVersion": {
+                            "kind": "hashedrekord",
+                            "version": "0.0.1"
+                        },
+                        "integratedTime": "1748978445",
+                        "inclusionPromise": {
+                            "signedEntryTimestamp": "MEUCIQCNuRResQCE4b2mA5/+gTwctji/1qL67SbeaciSlgj6NQIgE7vY0Fdoem2aODoKaHoieIRo89rcg7mX2mZL3B/XYh8="
+                        },
+                        "inclusionProof": {
+                            "logIndex": "107045287",
+                            "rootHash": "hgR6aB6kU+T1uo4iUx75tlIhKkYbUyPsHac2yhFgZpE=",
+                            "treeSize": "107045297",
+                            "hashes": [
+                                "31ltlTE5JIioyJ8rdH3OjwO9d3Us17sfd29GleLF5J0=",
+                                "AkqFsr2XZZPs2xu+kw64e2CheTwS6pgmH1DXBgpJfAo=",
+                                "LJsE/B9ZOF5PmmdxEQjiLmyHEEzfGmsX9HiXp3ZTiTU=",
+                                "VEnlDOQVZn3+NExF7G53geFQZYNf6U5DexkG4vgRlLQ=",
+                                "auvWhUrmnBq8g0KEcbAMvjyfrOYhAmiC5+yXjoBsGiw=",
+                                "8Cr3zC0dQe124OAQufmKfTZ8lnAYWQuw6AnXuy6DDMQ=",
+                                "tbcHjIX6G446NLcoiLw+hjALDmPwWWErWEOvrndCH7Q=",
+                                "Bj4reJ88xQpUq0P43RDNLi1sLcLaEeH443F87S4CHoc=",
+                                "mAX/zvx1jR0ujLtDApsQpHyxmoDGidClHMOn0BX1aQA=",
+                                "u5LKLBPTYgXZg0fBi6/8LuEeNy3EBAxJF0AkkB4Co6E=",
+                                "SPUVncwJRVX/n/RICCYqLpAzraqx7S0eMdXRr1RLRgg=",
+                                "uEJFtwcGQJMd9kjQhkXb7gl2WD3WMElCc15uDFvFGxs=",
+                                "VdOKzpQhJlpXgijzXANf/hNlje1G/N1kUuVnKNskkso=",
+                                "mta5fH/gFwxJ/0fT8yGpn3sFCY0G1RY555Iflm0LInM=",
+                                "7v8qPHNDLerpduaMx06eb/MwgoQwczTn/cYGKX/9wZ4="
+                            ],
+                            "checkpoint": {
+                                "envelope": "rekor.sigstore.dev - 1193050959916656506\n107045297\nhgR6aB6kU+T1uo4iUx75tlIhKkYbUyPsHac2yhFgZpE=\n\n\u2014 rekor.sigstore.dev wNI9ajBFAiEAqS6BBP1515FNbJUk/993J1ftsTnoVvZ3qFtXGB5WT6cCIGjBPbInr7P6zATImuD6RaTQfWxcPpmcquKCZbAnIseq\n"
+                            }
+                        },
+                        "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI2MWE0MjkxOWUxM2Q1MzlmNzY3M2NmMTFkMWM0MDQzODBlMjhlNTQwNTEwODYwYjlkMjQyMTk2ZTE2NTcwOWM5In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJRVJHRUpUU0RXOVhjR0lDbFZKVXdXOFcyeTlHdVRIQnNJUXozTE9pVkU1R0FpQWFINnVTdVBSNmYvbURkeXN0Q1JLZWVreWdrVmZvQ3gyekJGWGVNRUNxNEE9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTXdSRU5EUVd4WFowRjNTVUpCWjBsVlJ6SXlPVkpMYUVsV1NFaE9hSElyWWxwV05UVlFPRVl2U21sWmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFZkMDVxUVhwTlZHdDVUVVJSTVZkb1kwNU5hbFYzVG1wQmVrMVVhM3BOUkZFeFYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZJUVdScmF6TkhiVkZUVkV4SVlVRXpjV2R6T0UxMGJ6azNUMU5XWWxab1lVNWllbE1LUmpKbFlYUm5SRWxMU2xWclZVWTVRa1p4ZUN0U1MxWlpZa2hWTlVaUlNraGtkMEUxVkRZM1QyWm9ZVVJaU0dsNVlYRlBRMEZZVVhkblowWjNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZoUWpCSUNtMUpielk1U1ZSdVZUa3hjbmwxZVVGTFV6Um9jMkpuZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoUldVUldVakJTUVZGSUwwSkNUWGRGV1VWUVlraFdjbGxZVGpaUlIzaG9ZbTFrYUV4dVFuTk5RM2RIUTJselIwRlJVVUpuTnpoM1FWRkZSUXBJYldnd1pFaENlazlwT0haYU1td3dZVWhXYVV4dFRuWmlVemx6WWpKa2NHSnBPWFpaV0ZZd1lVUkJkVUpuYjNKQ1owVkZRVmxQTDAxQlJVbENRMEZOQ2todGFEQmtTRUo2VDJrNGRsb3liREJoU0ZacFRHMU9kbUpUT1hOaU1tUndZbWs1ZGxsWVZqQmhSRU5DYVhkWlMwdDNXVUpDUVVoWFpWRkpSVUZuVWprS1FraHpRV1ZSUWpOQlRqQTVUVWR5UjNoNFJYbFplR3RsU0Vwc2JrNTNTMmxUYkRZME0ycDVkQzgwWlV0amIwRjJTMlUyVDBGQlFVSnNlbU01VEZwM1FRcEJRVkZFUVVWbmQxSm5TV2hCUzFaNFJFcHViMjF6VjBwaFdFaHpTMHQxTVRseFZuWm1ZVkJ1ZDBzMVdWRllSMjlKT1ZOTGJpdE9Ta0ZwUlVFclEweHNDalV2VmtSTlV5dFZUVlk0VG1nck9EbEtNbnBqY0dONWNFVm9kelpETkhSWE1VSkRRM1ZFUVhkRFoxbEpTMjlhU1hwcU1FVkJkMDFFWVZGQmQxcG5TWGdLUVVsRGRHNTNWVzlzWTAweFoyczNTa0poYlhaR1RWTjNPVXN4V1Zob1ZHRkZjbWRVVmxSc1Nrc3JjRlo1TjBkdWRVYzVjMFprUWtGdk1XTjFNbXc0U3dwd2QwbDRRVkJoTUhNeVlqWmpielp3VVdaSWVGaGlWRUZFUW5Od05GZFVObGx0YVZjM1FTczVNa3BzZDFrNE4zWkVLemRrVURGeVMzcFhNMDVYVWxwUENrVTFRbTV4VVQwOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSyJ9fX19"
+                    }
+                ],
+                "timestampVerificationData": {}
+            },
+            "messageSignature": {
+                "messageDigest": {
+                    "algorithm": "SHA2_256",
+                    "digest": "YaQpGeE9U592c88R0cQEOA4o5UBRCGC50kIZbhZXCck="
+                },
+                "signature": "MEQCIERGEJTSDW9XcGIClVJUwW8W2y9GuTHBsIQz3LOiVE5GAiAaH6uSuPR6f/mDdystCRKeekygkVfoCx2zBFXeMECq4A=="
+            }
+        }
+    }
+]


### PR DESCRIPTION
The fetcher broke with some of the recent 3.14 release changes, most notably the inclusion of the release manager in the release JSON listing and Windows release manifests in each release's downloads table.